### PR TITLE
Merge 'Implement lobby' into 'implement-websocket'

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -1,0 +1,67 @@
+package ch.uzh.ifi.hase.soprafs24.controller;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPostResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Lobby Controller
+ * This class is responsible for handling all REST request that are related to
+ * the lobby.
+ * The controller will receive the request and delegate the execution to the
+ * LobbyService and finally return the result.
+ */
+@RestController
+public class LobbyController {
+    private final LobbyService lobbyService;
+    private final UserService userService;
+
+    LobbyController(LobbyService lobbyService, UserService userService) {
+        this.lobbyService = lobbyService;
+        this.userService = userService;
+    }
+
+    @PostMapping("/lobbies")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseBody
+    public LobbyPostResponseDTO createLobby(@RequestHeader String token) {
+
+        // authenticate user
+        User authUser = userService.authorizeUser(token);
+
+        Lobby createdLobby = lobbyService.createLobby(authUser);
+
+        return DTOMapper.INSTANCE.convertEntityToLobbyPostResponseDTO(createdLobby);
+    }
+    // TODO remove code
+   /* @GetMapping("/lobbies/{lobbyId}")
+
+    public ResponseEntity<String> joinLobby(@RequestHeader String token, @PathVariable String lobbyId) {
+
+        // authenticate user
+        userService.authorizeUser(token);
+
+        lobbyService.joinLobby(lobbyId);
+
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Upgrade", "websocket");
+        responseHeaders.set("Connection", "Upgrade");
+        return new ResponseEntity<>(responseHeaders, HttpStatus.SWITCHING_PROTOCOLS);
+    }
+
+    @DeleteMapping("/lobbies/{lobbyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseBody
+    public void exitLobby(@RequestHeader String token, @PathVariable String lobbyId) {
+
+        // authenticate user
+        User authUser = userService.authorizeUser(token);
+
+        lobbyService.leaveLobby(lobbyId, authUser);
+    }*/
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -1,0 +1,44 @@
+package ch.uzh.ifi.hase.soprafs24.entity;
+
+import ch.uzh.ifi.hase.soprafs24.game.GameSession;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "LOBBY")
+public class Lobby implements Serializable {
+
+    @Id
+    private Long lobbyId;
+
+    @OneToOne(mappedBy = "lobby", cascade = CascadeType.ALL)
+    private User user;
+
+
+    @ElementCollection
+    private List<Long> users = new ArrayList<>();
+
+    @Embedded()
+    private GameSession gameSession;
+
+    public void setLobbyId(Long lobbyId) {this.lobbyId = lobbyId;}
+
+    public Long getLobbyId() {return lobbyId;}
+
+    public void setUser(User user) {this.user = user;}
+
+    public User getUser() {return user;}
+
+    public List<Long> getUsers() {return users;}
+
+    public void addUsers(long userId) {users.add(userId);}
+
+    public boolean removeUsers(long userId) {return users.remove(userId);}
+
+    public GameSession getGameSession() {return gameSession;}
+
+    public void setGameSession(GameSession gameSession) {this.gameSession = gameSession;}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -33,6 +33,10 @@ public class User implements Serializable {
   @Column(nullable = false)
   private Integer lossCount = 0;
 
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "lobby_id")
+  private Lobby lobby;
+
   public Long getId() {
     return id;
   }
@@ -88,4 +92,8 @@ public class User implements Serializable {
   public void setLossCount(Integer lossCount) {
     this.lossCount = lossCount;
   }
+
+  public void setLobby(Lobby lobby) {this.lobby = lobby;}
+
+  public Lobby getLobby() {return lobby;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/game/GameSession.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/game/GameSession.java
@@ -2,4 +2,5 @@ package ch.uzh.ifi.hase.soprafs24.game;
 
 // Placeholder class
 public class GameSession {
+	private Long gameId;
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepository.java
@@ -1,0 +1,10 @@
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository("lobbyRepository")
+public interface LobbyRepository extends JpaRepository<Lobby, String> {
+    Lobby findByLobbyId(Long lobbyId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   User findByUsername(String username);
 
   User findByToken(String token);
+
+  User findById(long id);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyPostResponseDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyPostResponseDTO.java
@@ -1,0 +1,10 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+public class LobbyPostResponseDTO {
+    private Long lobbyId;
+
+    public void setLobbyId(Long lobbyId) {
+        this.lobbyId = lobbyId;
+    }
+    public Long getLobbyId() {return lobbyId;}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.rest.dto;
 
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 
 public class UserGetDTO {
 
@@ -9,6 +10,7 @@ public class UserGetDTO {
   private UserStatus status;
   private Integer winCount;
   private Integer lossCount;
+  private Lobby lobby;
 
   public Long getId() {
     return id;
@@ -49,4 +51,8 @@ public class UserGetDTO {
   public void setLossCount(Integer lossCount) {
     this.lossCount = lossCount;
   }
+
+  public Lobby getLobby() {return lobby;}
+
+  public void setLobby(Lobby lobby) {this.lobby = lobby;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -1,6 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.rest.mapper;
 
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyPostResponseDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.UserPostDTO;
 import org.mapstruct.*;
@@ -29,6 +31,7 @@ public interface DTOMapper {
   @Mapping(target = "status", ignore = true)
   @Mapping(target = "winCount", ignore = true)
   @Mapping(target = "lossCount", ignore = true)
+  @Mapping(target = "lobby", ignore = true)
   User convertUserPostDTOtoEntity(UserPostDTO userPostDTO);
 
   @Mapping(source = "id", target = "id")
@@ -36,5 +39,9 @@ public interface DTOMapper {
   @Mapping(source = "status", target = "status")
   @Mapping(source = "winCount", target = "winCount")
   @Mapping(source = "lossCount", target = "lossCount")
+  @Mapping(target = "lobby", ignore = true)
   UserGetDTO convertEntityToUserGetDTO(User user);
+  
+  @Mapping(source="lobbyId", target = "lobbyId")
+  LobbyPostResponseDTO convertEntityToLobbyPostResponseDTO(Lobby lobby);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -1,0 +1,88 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
+import javassist.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+
+/**
+ * Lobby Service
+ * This class is the "worker" and responsible for all functionality related to
+ * the lobby
+ * (e.g., it creates, modifies, deletes, finds). The result will be passed back
+ * to the caller.
+ */
+
+@Service
+@Transactional
+public class LobbyService {
+    private final Logger log = LoggerFactory.getLogger(LobbyService.class);
+
+    private final LobbyRepository lobbyRepository;
+    private final UserService userService;
+
+    @Autowired
+    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository, UserService userService) {
+        this.lobbyRepository = lobbyRepository;
+        this.userService = userService;
+    }
+
+    public Lobby createLobby(User user){
+        Lobby newLobby = new Lobby();
+        newLobby.setLobbyId(generateId());
+        user.setLobby(newLobby);
+        newLobby.setUser(user);
+        return lobbyRepository.save(newLobby);
+    }
+
+    public void joinLobby(long lobbyId, long userId) throws NotFoundException {
+        checkIfLobbyExists(lobbyId);
+        userService.checkIfUserExists(userId);
+        Lobby lobby = lobbyRepository.findByLobbyId(lobbyId);
+        lobby.addUsers(userId);
+        this.lobbyIsFull(lobbyId);
+    }
+
+    public void leaveLobby(long lobbyId, long userId) throws NotFoundException {
+        checkIfLobbyExists(lobbyId);
+        userService.checkIfUserExists(userId);
+        Lobby lobby = lobbyRepository.findByLobbyId(lobbyId);
+        if(!lobby.removeUsers(userId)){
+            String msg = "User " + userId + " is not part of lobby " + lobby.getLobbyId();
+            throw new NoSuchElementException(msg);
+        }
+    }
+
+    public boolean lobbyIsFull(long lobbyId) {
+        Lobby lobby = lobbyRepository.findByLobbyId(lobbyId);
+        return lobby.getUsers().size() == 4;
+    }
+
+    public void checkIfLobbyExists(long lobbyId) throws NotFoundException {
+        if (lobbyRepository.findByLobbyId(lobbyId) == null) {
+            String msg = "No lobby with id " + lobbyId + " found";
+            throw new NotFoundException(msg);
+        }
+
+    }
+
+    public long generateId() {
+        Random random = new Random();
+        long randomId;
+        do {
+            randomId = random.nextInt(9000) + 1000;
+        } while (lobbyRepository.findByLobbyId(randomId) != null);
+        return randomId;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -38,7 +38,8 @@ public class LobbyService {
         this.userService = userService;
     }
 
-    public Lobby createLobby(User user){
+    // TODO consider if lobby already exists check
+    public Lobby createLobby(User user) {
         Lobby newLobby = new Lobby();
         newLobby.setLobbyId(generateId());
         user.setLobby(newLobby);
@@ -49,7 +50,20 @@ public class LobbyService {
     public void joinLobby(long lobbyId, long userId) throws NotFoundException {
         checkIfLobbyExists(lobbyId);
         userService.checkIfUserExists(userId);
+
+        // check if lobby is already full
+        if (lobbyIsFull(lobbyId)) {
+            String msg = "The lobby is already full";
+            throw new IllegalStateException(msg);
+        }
+
         Lobby lobby = lobbyRepository.findByLobbyId(lobbyId);
+
+        // check if user is already in the lobby
+        if (lobby.getUsers().contains(userId)) {
+            String msg = "The user is already in the lobby";
+            throw new IllegalStateException(msg);
+        }
         lobby.addUsers(userId);
         this.lobbyIsFull(lobbyId);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs24.service;
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import javassist.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,14 @@ public class UserService {
         newUser.setWinCount(0);
         newUser.setLossCount(0);
         return userRepository.save(newUser);
+    }
+
+    // TODO eventually refactor better to avoid duplicate code
+    public void checkIfUserExists(long userId) throws NotFoundException {
+      if(userRepository.findById(userId) == null) {
+          String msg = "User with id " + userId + " does not exist";
+          throw new NotFoundException(msg);
+      }
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -1,0 +1,79 @@
+package ch.uzh.ifi.hase.soprafs24.controller;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+/**
+ * LobbyControllerTest
+ * This is a WebMvcTest which allows to test the LobbyController i.e. GET/POST
+ * request without actually sending them over the network.
+ * This tests if the LobbyController works.
+ */
+
+@WebMvcTest(LobbyController.class)
+public class LobbyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LobbyService lobbyService;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    public void createLobby_lobbyCreated() throws Exception {
+        //given
+
+        Lobby lobby = new Lobby();
+        lobby.setLobbyId(1225L);
+
+        given(lobbyService.createLobby(Mockito.any())).willReturn(lobby);
+
+        // when/then -> do the request + validate the result
+        MockHttpServletRequestBuilder postRequest = post("/lobbies")
+                .contentType(MediaType.APPLICATION_JSON).header("Token", "placeholder-token");
+
+        // then
+        mockMvc.perform(postRequest)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.lobbyId", is(lobby.getLobbyId().intValue())));
+    }
+
+    @Test
+    public void createLobby_invalidAuth_lobbyNotCreated() throws Exception {
+        //given
+
+       Lobby lobby = new Lobby();
+       lobby.setLobbyId(1225L);
+
+        given(userService.authorizeUser("placeholder-token"))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"));
+
+       // when/then -> do the request + validate the result
+    MockHttpServletRequestBuilder postRequest = post("/lobbies")
+               .contentType(MediaType.APPLICATION_JSON).header("Token", "placeholder-token");
+
+       // then
+      mockMvc.perform(postRequest)
+              .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepositoryIntegrationTest.java
@@ -1,0 +1,54 @@
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+public class LobbyRepositoryIntegrationTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private LobbyRepository lobbyRepository;
+
+    // 1
+    @Test
+    public void findByLobbyId_success() {
+        // given
+        Lobby lobby = new Lobby();
+        lobby.setLobbyId(1000L);
+        entityManager.persist(lobby);
+        entityManager.flush();
+
+        // when
+        Lobby found = lobbyRepository.findByLobbyId(lobby.getLobbyId());
+
+        // then
+        assertNotNull(found.getLobbyId());
+        assertEquals(found.getLobbyId(), lobby.getLobbyId());
+    }
+
+    @Test
+    public void findByLobbyId_returnsNull() {
+        // given
+        Lobby lobby = new Lobby();
+        lobby.setLobbyId(1000L);
+
+        entityManager.persist(lobby);
+        entityManager.flush();
+
+        // when
+        Lobby found = lobbyRepository.findByLobbyId(1111L);
+
+        // then
+        assertNull(found);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepositoryIntegrationTest.java
@@ -83,4 +83,46 @@ public class UserRepositoryIntegrationTest {
         // then
         assertNull(found);
     }
+    @Test
+    public void findById_success() {
+        // given
+        User user = new User();
+        user.setUsername("firstname@lastname");
+        user.setPassword("password");
+        user.setStatus(UserStatus.OFFLINE);
+        user.setToken("1");
+
+        entityManager.persist(user);
+        entityManager.flush();
+
+        // when
+        User found = userRepository.findById(user.getId().longValue());
+
+        // then
+        assertNotNull(found.getId());
+        assertEquals(found.getId(), user.getId());
+        assertEquals(found.getUsername(), user.getUsername());
+        assertEquals(found.getPassword(), user.getPassword());
+        assertEquals(found.getToken(), user.getToken());
+        assertEquals(found.getStatus(), user.getStatus());
+    }
+
+    @Test
+    public void findById_returnsNull() {
+        // given
+        User user = new User();
+        user.setUsername("firstname@lastname");
+        user.setPassword("password");
+        user.setStatus(UserStatus.OFFLINE);
+        user.setToken("1");
+
+        entityManager.persist(user);
+        entityManager.flush();
+
+        // when
+        User found = userRepository.findById(user.getId() + 1L);
+
+        // then
+        assertNull(found);
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -60,7 +60,8 @@ public class LobbyServiceIntegrationTest {
 
         // then:
         assertNotNull(createdLobby.getLobbyId(), "The id of the lobby was not created");
+        assertEquals(createdLobby.getLobbyId(), testUser.getLobby().getLobbyId(), "The correct db association was not created");
+        assertEquals(createdLobby.getUser().getId(),testUser.getId(), "The correct db association was not created");
     }
 
-    //TODO test for database relation between lobby and user
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -1,0 +1,66 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Test class for the LobbyResource REST resource.
+ *
+ * @see UserService
+ */
+@WebAppConfiguration
+@SpringBootTest
+public class LobbyServiceIntegrationTest {
+
+    @Qualifier("lobbyRepository")
+    @Autowired
+    private LobbyRepository lobbyRepository;
+
+    @Autowired
+    private LobbyService lobbyService;
+
+    @Qualifier("userRepository")
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    public void setup() {
+        lobbyRepository.deleteAll();
+    }
+
+    @Test
+    public void createLobby_success() {
+        // given:
+        assertNull(lobbyRepository.findByLobbyId(1000L));
+
+        User testUser = new User();
+        testUser.setUsername("testUsername");
+        testUser.setPassword("testPassword");
+        testUser.setStatus(UserStatus.ONLINE);
+        testUser.setToken("testToken");
+        testUser = userRepository.save(testUser);
+
+        // when:
+        Lobby createdLobby = lobbyService.createLobby(testUser);
+
+        // then:
+        assertNotNull(createdLobby.getLobbyId(), "The id of the lobby was not created");
+    }
+
+    //TODO test for database relation between lobby and user
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -1,0 +1,208 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import javassist.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+
+public class LobbyServiceTest {
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @InjectMocks
+    private LobbyService lobbyService;
+
+    @InjectMocks
+    private Lobby testLobby;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private User testUser;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        // given
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setUsername("testUsername");
+        testUser.setPassword("testPassword");
+        testUser.setToken("dummy-token");
+        testUser.setStatus(UserStatus.OFFLINE);
+        testUser.setWinCount(0);
+        testUser.setLossCount(0);
+
+        testLobby = new Lobby();
+        testLobby.setLobbyId(1000L);
+
+        // when -> any object is being saved in the userRepository -> return the dummy
+        // testLobby
+        Mockito.when(lobbyRepository.save(Mockito.any())).thenReturn(testLobby);
+    }
+
+    @Test
+    public void createLobby_validInputs_success()  {
+
+        Lobby createdLobby = lobbyService.createLobby(testUser);
+
+        Mockito.verify(lobbyRepository, Mockito.times(1)).save(Mockito.any(Lobby.class));
+        assertNotNull(createdLobby);
+        assertNotNull(createdLobby.getLobbyId());
+    }
+
+    @Test
+    public void isFull_true()  {
+
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+        testLobby.addUsers(3L);
+        testLobby.addUsers(4L);
+        // when -> setup additional mocks for LobbyRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        assertTrue(lobbyService.lobbyIsFull(testLobby.getLobbyId()));
+    }
+
+    @Test
+    public void isFull_notEmpty_false()  {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+
+        // when -> setup additional mocks for LobbyRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        assertFalse(lobbyService.lobbyIsFull(testLobby.getLobbyId()));
+    }
+
+    @Test
+    public void isFull_Empty_false()  {
+        // when -> setup additional mocks for LobbyRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        assertFalse(lobbyService.lobbyIsFull(testLobby.getLobbyId()));
+    }
+
+    @Test
+    public void joinLobby_validInputs_success() throws NotFoundException {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+
+        ArrayList<Long> users = new ArrayList<>();
+        users.add(1L);
+        users.add(2L);
+        users.add(3L);
+
+        // when -> setup additional mocks for LobbyRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+        Mockito.when(userRepository.findById(Mockito.anyLong())).thenReturn(testUser);
+
+
+        lobbyService.joinLobby(testLobby.getLobbyId(), 3L);
+
+        assertEquals(testLobby.getUsers(), users);
+    }
+
+    @Test
+    public void joinLobby_duplicatedInputs_noSuccess() throws Exception {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+
+        ArrayList<Long> users = new ArrayList<>();
+        users.add(1L);
+        users.add(2L);
+
+        // when -> setup additional mocks for LobbyRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        assertThrows(
+                IllegalStateException.class, () -> lobbyService
+                        .joinLobby(testLobby.getLobbyId(), 2L));
+
+    }
+
+    @Test
+    public void joinLobby_NonExistentUser_noSuccess() throws NotFoundException {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+
+        // when -> setup additional mocks for LobbyRepository and userRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+        doThrow(new NotFoundException("error")).when(userService).checkIfUserExists(Mockito.anyLong());
+
+        assertThrows(
+                NotFoundException.class, () -> lobbyService
+                        .joinLobby(testLobby.getLobbyId(), 3L));
+
+    }
+
+    @Test
+    public void joinLobby_full_noSuccess()  {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+        testLobby.addUsers(3L);
+        testLobby.addUsers(4L);
+
+        // when -> setup additional mocks for LobbyRepository and userRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        assertThrows(
+                IllegalStateException.class, () -> lobbyService
+                        .joinLobby(testLobby.getLobbyId(), 5L));
+
+    }
+
+    @Test
+    public void leaveLobby_validInputs_success() throws Exception  {
+        testLobby.addUsers(1L);
+
+        // when -> setup additional mocks for LobbyRepository and userRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        lobbyService.leaveLobby(testLobby.getLobbyId(), 1L);
+
+        assertEquals(new ArrayList<>(), testLobby.getUsers());
+
+    }
+
+    @Test
+    public void leaveLobby_NonExistentUser_noSuccess()  throws Exception {
+        testLobby.addUsers(1L);
+
+        // when -> setup additional mocks for LobbyRepository and userRepository
+        Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
+
+        assertThrows(
+                NoSuchElementException.class, () -> lobbyService
+                        .leaveLobby(testLobby.getLobbyId(), 2L));
+
+    }
+
+    @Test
+    public void generateId_success()  {
+        long id = lobbyService.generateId();
+        assertNotNull(id);
+    }
+
+}
+

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceIntegrationTest.java
@@ -54,6 +54,7 @@ public class UserServiceIntegrationTest {
     assertEquals(UserStatus.ONLINE, createdUser.getStatus());
     assertEquals(0, createdUser.getWinCount());
     assertEquals(0, createdUser.getLossCount());
+    assertNull(createdUser.getLobby(), "The lobby is not null created");
   }
 
   // # 1

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs24.service;
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import javassist.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -190,6 +191,30 @@ public class UserServiceTest {
         // call userService method
         userService.logoutUser(testUser);
         assertEquals(UserStatus.OFFLINE, testUser.getStatus());
+    }
+
+    @Test
+    public void checkIfUserExists_success() throws NotFoundException {
+        // given -> a first user has already been created
+        userService.createUser(testUser);
+
+        // when -> setup additional mocks for UserRepository
+        Mockito.when(userRepository.findById(Mockito.anyLong())).thenReturn(testUser);
+
+        assertDoesNotThrow(() -> userService.checkIfUserExists(testUser.getId()));
+
+    }
+
+    @Test
+    public void checkIfUserExists_throwsException() {
+        // given -> a first user has already been created
+        userService.createUser(testUser);
+
+        // when -> setup additional mocks for UserRepository
+        Mockito.when(userRepository.findById(Mockito.anyLong())).thenReturn(null);
+
+        assertThrows(
+                NotFoundException.class, () -> userService.checkIfUserExists(1L));
     }
 
 }


### PR DESCRIPTION
Merging the lobby implementation into the websocket one, so that they can then be developed and tested together before merging to main.
What was added:
- Controller to create new lobbies with POST request
- Lobbyservice
- Lobby entity and repo with a one to one relationship with User (the owning entity)
- Too many tests

~n.b. tests for the relationship between the User and the Lobby entity still miss.~ ok I quickly added two new lines that might suffice