### PR TITLE
Fix db and missing endpoint auth, add REST endpoint, better conflict and lobby creation handling, lobby destruction; [see description]

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/Application.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/Application.java
@@ -19,7 +19,6 @@ public class Application {
 
   @GetMapping(value = "/", produces = MediaType.TEXT_PLAIN_VALUE)
   @ResponseStatus(HttpStatus.OK)
-  @ResponseBody
   public String helloWorld() {
     return "The application is running.";
   }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/Application.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/Application.java
@@ -30,7 +30,7 @@ public class Application {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("http://localhost:3000", "https://sopra-fs25-group-22-client.vercel.app")
                 .allowedMethods("*")
                 .exposedHeaders("Token");
       }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
@@ -16,7 +16,7 @@ import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.AiRequestDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.ChosenCaptureDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.PlayCardDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.util.Pair;
@@ -60,8 +60,7 @@ public class MessageController {
             success = false;
         }
 
-        // TODO refactor DTO name
-        UserJoinNotificationDTO notificationDTO = webSocketService.convertToDTO(msg, success);
+        UserNotificationDTO notificationDTO = webSocketService.convertToDTO(msg, success);
         webSocketService.broadCastLobbyNotifications(lobbyId, notificationDTO);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -32,7 +32,6 @@ public class UserController {
 
   @GetMapping("/users")
   @ResponseStatus(HttpStatus.OK)
-  @ResponseBody
   public List<UserGetDTO> getAllUsers(@RequestHeader String token) {
     userService.authorizeUser(token);
 
@@ -49,16 +48,14 @@ public class UserController {
 
     @GetMapping("/users/{userId}")
     @ResponseStatus(HttpStatus.OK)
-    @ResponseBody
     public UserGetDTO getUser(@RequestHeader String token, @PathVariable Long userId) {
         userService.authorizeUser(token);
         // fetch specific user in the internal representation
         User user = userService.getUserById(userId);
 
-        // convert  user to the API representation
-        UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
+        // convert and return user to the API representation
 
-        return userGetDTO;
+        return DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
     }
 
   @PostMapping("/login")
@@ -90,13 +87,11 @@ public class UserController {
     HttpHeaders responseHeaders = new HttpHeaders();
     responseHeaders.set("Token", createdUser.getToken());
     UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(createdUser);
-    System.out.println("=================USER REGISTERED===============");
     return new ResponseEntity<>(userGetDTO, responseHeaders, HttpStatus.CREATED);
   }
 
     @PostMapping("/logout")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @ResponseBody
     public void logoutUser(@RequestHeader String token) {
         User authUser = userService.authorizeUser(token);
         userService.logoutUser(authUser);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -33,7 +33,9 @@ public class UserController {
   @GetMapping("/users")
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public List<UserGetDTO> getAllUsers() {
+  public List<UserGetDTO> getAllUsers(@RequestHeader String token) {
+    userService.authorizeUser(token);
+
     // fetch all users in the internal representation
     List<User> users = userService.getUsers();
     List<UserGetDTO> userGetDTOs = new ArrayList<>();
@@ -44,6 +46,20 @@ public class UserController {
     }
     return userGetDTOs;
   }
+
+    @GetMapping("/users/{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public UserGetDTO getUser(@RequestHeader String token, @PathVariable Long userId) {
+        userService.authorizeUser(token);
+        // fetch specific user in the internal representation
+        User user = userService.getUserById(userId);
+
+        // convert  user to the API representation
+        UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
+
+        return userGetDTO;
+    }
 
   @PostMapping("/login")
   public ResponseEntity<String> loginUser(@RequestBody UserPostDTO userPostDTO) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -14,7 +14,7 @@ public class Lobby implements Serializable {
     @Id
     private Long lobbyId;
 
-    @OneToOne(mappedBy = "lobby", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "lobby")
     private User user;
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -33,6 +33,9 @@ public class User implements Serializable {
   @Column(nullable = false)
   private Integer lossCount = 0;
 
+  @Column
+  private Long lobbyJoined;
+
   @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "lobby_id")
   private Lobby lobby;
@@ -119,4 +122,8 @@ public class User implements Serializable {
   public void incrementTieCount() {
     this.tieCount++;
   }
+
+  public Long getLobbyJoined() {return lobbyJoined;}
+
+  public void setLobbyJoined(Long lobbyJoined) {this.lobbyJoined = lobbyJoined;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository("lobbyRepository")
-public interface LobbyRepository extends JpaRepository<Lobby, String> {
-    Lobby findByLobbyId(Long lobbyId);
+public interface LobbyRepository extends JpaRepository<Lobby, Long> {
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
@@ -12,6 +12,7 @@ public class UserGetDTO {
   private Integer lossCount;
   private Lobby lobby;
   private Integer tieCount;
+  private Long lobbyJoined;
 
   public Long getId() {
     return id;
@@ -64,4 +65,10 @@ public class UserGetDTO {
   public void setTieCount(Integer tieCount) {
     this.tieCount = tieCount;
   }
+
+  public void setLobbyJoined(Long lobbyJoined) {
+        this.lobbyJoined = lobbyJoined;
+  }
+
+  public Long getLobbyJoined() {return lobbyJoined;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -33,6 +33,7 @@ public interface DTOMapper {
   @Mapping(target = "lossCount", ignore = true)
   @Mapping(target = "lobby", ignore = true)
   @Mapping(target = "tieCount", ignore = true)
+  @Mapping(target = "lobbyJoined", ignore = true)
   User convertUserPostDTOtoEntity(UserPostDTO userPostDTO);
 
   @Mapping(source = "id", target = "id")
@@ -42,6 +43,7 @@ public interface DTOMapper {
   @Mapping(source = "lossCount", target = "lossCount")
   @Mapping(target = "lobby", ignore = true)
   @Mapping(source = "tieCount", target = "tieCount")
+  @Mapping(target = "lobbyJoined", ignore = true)
   UserGetDTO convertEntityToUserGetDTO(User user);
 
   @Mapping(source="lobbyId", target = "lobbyId")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -4,6 +4,7 @@ package ch.uzh.ifi.hase.soprafs24.service;
 import java.util.NoSuchElementException;
 import java.util.Random;
 
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,23 +32,29 @@ public class LobbyService {
     private final Logger log = LoggerFactory.getLogger(LobbyService.class);
 
     private final LobbyRepository lobbyRepository;
+    private final UserRepository userRepository;
     private final UserService userService;
     private final Random random;
 
     @Autowired
-    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository, UserService userService) {
+    public LobbyService(@Qualifier("lobbyRepository") LobbyRepository lobbyRepository, UserRepository userRepository, UserService userService) {
         this.lobbyRepository = lobbyRepository;
+        this.userRepository = userRepository;
         this.userService = userService;
         this.random = new Random();
     }
 
     // TODO consider if user already has lobby check
     public Lobby createLobby(User user) {
+        if (user.getLobby() != null) {
+            return user.getLobby();
+        }
         Lobby newLobby = new Lobby();
         newLobby.setLobbyId(generateId());
         user.setLobby(newLobby);
         newLobby.setUser(user);
-        return lobbyRepository.save(newLobby);
+        userRepository.save(user);
+        return newLobby;
     }
 
     //TODO cleanup, add check if user already in a lobby
@@ -67,7 +74,6 @@ public class LobbyService {
         if (!lobby.getUsers().contains(userId)) {
             lobby.addUsers(userId);
         }
-        //lobbyIsFull(lobbyId);
     }
 
     public void leaveLobby(Long lobbyId, Long userId) throws NotFoundException {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -41,6 +41,15 @@ public class UserService {
     return this.userRepository.findAll();
   }
 
+
+  public User getUserById(Long id) {
+      Optional<User> user = this.userRepository.findById(id);
+      if (user.isEmpty()) {
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User with id " + id + " not found");
+      }
+      return user.get();
+  }
+
   public String loginUser(User userInput) {
     User userByUsername = userRepository.findByUsername(userInput.getUsername());
     if (userByUsername == null) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
@@ -1,8 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
 import javassist.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -22,14 +22,14 @@ public class WebSocketService {
         this.userService = userService;
     }
 
-    // broadcast lobby join/leave messages to lobby users
+    // broadcast lobby join/leave messages (and other notifications) to lobby users
     public void broadCastLobbyNotifications(Long lobbyId, Object DTO) {
 
         // broadcast notification to right lobby
         messagingTemplate.convertAndSend("/topic/lobby/" + lobbyId, DTO);
     }
 
-    // sent join notification back to specific user
+    // sent (join) notification back to specific user
     public void lobbyNotifications(Long userId, Object DTO) {
 
         // send notification to user
@@ -37,18 +37,18 @@ public class WebSocketService {
 
     }
 
-    // method for creating DTO to broadcast lobby joining notifications
-    public UsersBroadcastJoinNotificationDTO convertToDTO(Long userId, String status) throws NotFoundException {
+    // method for creating DTO to broadcast lobby (joining) notifications
+    public UsersBroadcastNotificationDTO convertToDTO(Long userId, String status) throws NotFoundException {
         User user = userService.checkIfUserExists(userId);
-        UsersBroadcastJoinNotificationDTO DTO = new UsersBroadcastJoinNotificationDTO();
+        UsersBroadcastNotificationDTO DTO = new UsersBroadcastNotificationDTO();
         DTO.setStatus(status);
         DTO.setUsername(user.getUsername());
         return DTO;
     }
 
-    // method overload to create DTO for private user joining notifications
-    public UserJoinNotificationDTO convertToDTO(String msg, boolean success) {
-        UserJoinNotificationDTO DTO = new UserJoinNotificationDTO();
+    // method overload to create DTO for private user (joining) notifications
+    public UserNotificationDTO convertToDTO(String msg, boolean success) {
+        UserNotificationDTO DTO = new UserNotificationDTO();
         DTO.setSuccess(success);
         DTO.setMessage(msg);
         return DTO;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
@@ -3,7 +3,7 @@ package ch.uzh.ifi.hase.soprafs24.service;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.BroadcastNotificationDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
 import javassist.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -39,9 +39,9 @@ public class WebSocketService {
     }
 
     // method for creating DTO to broadcast lobby (joining) notifications
-    public UsersBroadcastNotificationDTO convertToDTO(Long userId, String status) throws NotFoundException {
+    public UsersBroadcastJoinNotificationDTO convertToDTO(Long userId, String status) throws NotFoundException {
         User user = userService.checkIfUserExists(userId);
-        UsersBroadcastNotificationDTO DTO = new UsersBroadcastNotificationDTO();
+        UsersBroadcastJoinNotificationDTO DTO = new UsersBroadcastJoinNotificationDTO();
         DTO.setStatus(status);
         DTO.setUsername(user.getUsername());
         return DTO;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.BroadcastNotificationDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
 import javassist.NotFoundException;
@@ -50,6 +51,12 @@ public class WebSocketService {
     public UserNotificationDTO convertToDTO(String msg, boolean success) {
         UserNotificationDTO DTO = new UserNotificationDTO();
         DTO.setSuccess(success);
+        DTO.setMessage(msg);
+        return DTO;
+    }
+
+    public BroadcastNotificationDTO convertToDTO(String msg) {
+        BroadcastNotificationDTO DTO = new BroadcastNotificationDTO();
         DTO.setMessage(msg);
         return DTO;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/BroadcastNotificationDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/BroadcastNotificationDTO.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.DTO;
+
+public class BroadcastNotificationDTO {
+    private String message;
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {return message;}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/UserNotificationDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/UserNotificationDTO.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.websocket.DTO;
 
-public class UserJoinNotificationDTO {
+public class UserNotificationDTO {
 
     private boolean success;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/UsersBroadcastJoinNotificationDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/UsersBroadcastJoinNotificationDTO.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.websocket.DTO;
 
-public class UsersBroadcastNotificationDTO {
+public class UsersBroadcastJoinNotificationDTO {
 
     private String username;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/UsersBroadcastNotificationDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/UsersBroadcastNotificationDTO.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.websocket.DTO;
 
-public class UsersBroadcastJoinNotificationDTO {
+public class UsersBroadcastNotificationDTO {
 
     private String username;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
@@ -16,8 +16,8 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
 import javassist.NotFoundException;
 
 @Component
@@ -56,7 +56,7 @@ public class WebSocketEventListener {
                 log.info("Lobby {} joined successfully", lobbyId);
 
                 // broadcast msg to lobby
-                UsersBroadcastJoinNotificationDTO DTO = webSocketService.convertToDTO(userId, "subscribed");
+                UsersBroadcastNotificationDTO DTO = webSocketService.convertToDTO(userId, "subscribed");
                 webSocketService.broadCastLobbyNotifications(lobbyId, DTO);
             } catch (NotFoundException | IllegalStateException e) {
                 msg = e.getMessage();
@@ -64,7 +64,7 @@ public class WebSocketEventListener {
             }
 
             // notify user
-            UserJoinNotificationDTO DTO = webSocketService.convertToDTO(msg, success);
+            UserNotificationDTO DTO = webSocketService.convertToDTO(msg, success);
             webSocketService.lobbyNotifications(userId, DTO);
         } else {
             log.debug("Received other sub protocol event: {}", event.getMessage());
@@ -96,7 +96,7 @@ public class WebSocketEventListener {
                 log.info("Lobby {} left successfully", lobbyId);
 
                 // broadcast msg to lobby
-                UsersBroadcastJoinNotificationDTO DTO = webSocketService.convertToDTO(userId, "subscribed");
+                UsersBroadcastNotificationDTO DTO = webSocketService.convertToDTO(userId, "subscribed");
                 webSocketService.broadCastLobbyNotifications(lobbyId, DTO);
             } catch (NotFoundException | IllegalStateException e) {
                 msg = e.getMessage();
@@ -104,7 +104,7 @@ public class WebSocketEventListener {
             }
 
             // notify user
-            UserJoinNotificationDTO DTO = webSocketService.convertToDTO(msg, success);
+            UserNotificationDTO DTO = webSocketService.convertToDTO(msg, success);
             webSocketService.lobbyNotifications(userId, DTO);
         } else {
             log.debug("Received other sub protocol event: {}", event.getMessage());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
@@ -18,7 +18,7 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
 import javassist.NotFoundException;
 
 @Component
@@ -57,7 +57,7 @@ public class WebSocketEventListener {
                 log.info("Lobby {} joined successfully", lobbyId);
 
                 // broadcast msg to lobby
-                UsersBroadcastNotificationDTO DTO = webSocketService.convertToDTO(userId, "subscribed");
+                UsersBroadcastJoinNotificationDTO DTO = webSocketService.convertToDTO(userId, "subscribed");
                 webSocketService.broadCastLobbyNotifications(lobbyId, DTO);
             } catch (NotFoundException | IllegalStateException e) {
                 msg = e.getMessage();
@@ -96,7 +96,7 @@ public class WebSocketEventListener {
                 log.info("Lobby {} left successfully", lobbyId);
 
                 // broadcast msg to lobby
-                UsersBroadcastNotificationDTO DTO = webSocketService.convertToDTO(userId, "unsubscribed");
+                UsersBroadcastJoinNotificationDTO DTO = webSocketService.convertToDTO(userId, "unsubscribed");
                 webSocketService.broadCastLobbyNotifications(lobbyId, DTO);
             } catch (NotFoundException e) {
                 msg = e.getMessage();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
@@ -108,6 +108,15 @@ public class WebSocketEventListener {
                 msg = "Lobby deleted successfully";
             }
 
+            // check if lobby has been deleted and set and broadcast right msg
+            try{lobbyService.checkIfLobbyExists(lobbyId);
+            } catch (NotFoundException e) {
+                msg = "Lobby with id {} has been deleted " + lobbyId;
+                BroadcastNotificationDTO broadcastDTO = webSocketService.convertToDTO(msg);
+                webSocketService.broadCastLobbyNotifications(lobbyId, broadcastDTO);
+                msg = "Lobby deleted successfully";
+            }
+
             // notify user
             UserNotificationDTO DTO = webSocketService.convertToDTO(msg, success);
             webSocketService.lobbyNotifications(userId, DTO);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -76,4 +76,22 @@ public class LobbyControllerTest {
       mockMvc.perform(postRequest)
               .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    void createLobby_conflict() throws Exception {
+        //given
+
+        Lobby lobby = new Lobby();
+        lobby.setLobbyId(1225L);
+
+        given(lobbyService.createLobby(Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.CONFLICT));
+
+        // when/then -> do the request + validate the result
+        MockHttpServletRequestBuilder postRequest = post("/lobbies")
+                .contentType(MediaType.APPLICATION_JSON).header("Token", "placeholder-token");
+
+        // then
+        mockMvc.perform(postRequest)
+                .andExpect(status().isConflict());
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
@@ -16,6 +16,7 @@ import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.ChosenCaptureDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.PlayCardDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import javassist.NotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -56,7 +57,7 @@ public class MessageControllerTest {
 
     // --- Test /app/startGame ---
     @Test
-    void testProcessStartGameSuccess() {
+    void testProcessStartGameSuccess() throws NotFoundException {
         // given
         LobbyDTO lobbyDTO = new LobbyDTO();
         lobbyDTO.setLobbyId(100L);
@@ -89,7 +90,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    void testProcessStartGameThrowsException() {
+    void testProcessStartGameThrowsException() throws NotFoundException {
         // given
         LobbyDTO lobbyDTO = new LobbyDTO();
         lobbyDTO.setLobbyId(100L);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
@@ -1,6 +1,5 @@
 package ch.uzh.ifi.hase.soprafs24.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -16,7 +15,7 @@ import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.ChosenCaptureDTO;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.PlayCardDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -68,7 +67,7 @@ public class MessageControllerTest {
 
         String msg = "Starting game";
         GameSession dummyGame = new GameSession(lobby.getLobbyId(), lobby.getUsers());
-        UserJoinNotificationDTO dummyNotificationDTO = new UserJoinNotificationDTO();
+        UserNotificationDTO dummyNotificationDTO = new UserNotificationDTO();
         dummyNotificationDTO.setSuccess(Boolean.TRUE);
         dummyNotificationDTO.setMessage(msg);
 
@@ -86,7 +85,7 @@ public class MessageControllerTest {
         verify(webSocketService, times(1))
                 .convertToDTO(msg, true);
         verify(webSocketService, times(1))
-                .broadCastLobbyNotifications(eq(100L), any(UserJoinNotificationDTO.class));
+                .broadCastLobbyNotifications(eq(100L), any(UserNotificationDTO.class));
     }
 
     @Test
@@ -100,7 +99,7 @@ public class MessageControllerTest {
 
 
         String msg = "Lobby " + lobby.getLobbyId() + " is not full yet";
-        UserJoinNotificationDTO dummyNotificationDTO = new UserJoinNotificationDTO();
+        UserNotificationDTO dummyNotificationDTO = new UserNotificationDTO();
         dummyNotificationDTO.setSuccess(Boolean.FALSE);
         dummyNotificationDTO.setMessage(msg);
 
@@ -115,7 +114,7 @@ public class MessageControllerTest {
         verify(webSocketService, times(1))
                 .convertToDTO("Error starting game: " + msg, false);
         verify(webSocketService, times(1))
-                .broadCastLobbyNotifications(eq(100L), any(UserJoinNotificationDTO.class));
+                .broadCastLobbyNotifications(eq(100L), any(UserNotificationDTO.class));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/LobbyRepositoryIntegrationTest.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
@@ -21,7 +23,7 @@ public class LobbyRepositoryIntegrationTest {
 
     // 1
     @Test
-    public void findByLobbyId_success() {
+    public void findById_success() {
         // given
         Lobby lobby = new Lobby();
         lobby.setLobbyId(1000L);
@@ -29,15 +31,15 @@ public class LobbyRepositoryIntegrationTest {
         entityManager.flush();
 
         // when
-        Lobby found = lobbyRepository.findByLobbyId(lobby.getLobbyId());
+        Optional<Lobby> found = lobbyRepository.findById(lobby.getLobbyId());
 
         // then
-        assertNotNull(found.getLobbyId());
-        assertEquals(found.getLobbyId(), lobby.getLobbyId());
+        assertFalse(found.isEmpty());
+        assertEquals(found.get().getLobbyId(), lobby.getLobbyId());
     }
 
     @Test
-    public void findByLobbyId_returnsNull() {
+    public void findById_returnsNull() {
         // given
         Lobby lobby = new Lobby();
         lobby.setLobbyId(1000L);
@@ -46,9 +48,9 @@ public class LobbyRepositoryIntegrationTest {
         entityManager.flush();
 
         // when
-        Lobby found = lobbyRepository.findByLobbyId(1111L);
+        Optional<Lobby> found = lobbyRepository.findById(1111L);
 
         // then
-        assertNull(found);
+        assertTrue(found.isEmpty());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -40,9 +40,6 @@ public class LobbyServiceIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserService userService;
-
     @InjectMocks
     private User testUser;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -7,6 +7,8 @@ import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,22 +43,31 @@ public class LobbyServiceIntegrationTest {
     @Autowired
     private UserService userService;
 
+    @InjectMocks
+    private User testUser;
+
     @BeforeEach
-    public void setup() {
+    void setup() {
+        // given
+        MockitoAnnotations.openMocks(this);
+
         lobbyRepository.deleteAll();
-    }
-
-    @Test
-    public void createLobby_success() {
-        // given:
-        assertNull(lobbyRepository.findByLobbyId(1000L));
-
-        User testUser = new User();
+        testUser.setId(1L);
         testUser.setUsername("testUsername");
         testUser.setPassword("testPassword");
         testUser.setStatus(UserStatus.ONLINE);
         testUser.setToken("testToken");
+        testUser.setLossCount(0);
+        testUser.setTieCount(0);
+        testUser.setWinCount(0);
+
         testUser = userRepository.save(testUser);
+    }
+
+    @Test
+    void createLobby_success() {
+        // given:
+        assertNull(lobbyRepository.findByLobbyId(1000L));
 
         // when:
         Lobby createdLobby = lobbyService.createLobby(testUser);
@@ -68,17 +79,13 @@ public class LobbyServiceIntegrationTest {
     }
 
     @Test
-    public void joinLobby_success() {
-
-        User testUser = new User();
-        testUser.setUsername("testUsername");
-        testUser.setPassword("testPassword");
-        testUser.setStatus(UserStatus.ONLINE);
-        testUser.setToken("testToken");
-        testUser = userRepository.save(testUser);
+    void joinLobby_success() {
+        // given
+        List<Long> emptyList = new ArrayList<>();
+        Lobby createdLobby = lobbyService.createLobby(testUser);
+        assertEquals(emptyList, createdLobby.getUsers());
 
         // when:
-        Lobby createdLobby = lobbyService.createLobby(testUser);
         createdLobby.addUsers(1L);
         createdLobby.addUsers(2L);
         List<Long> userIds = new ArrayList<>();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -148,7 +148,7 @@ public class LobbyServiceIntegrationTest {
     }
 
     @Test
-    void leaveLobby_andDestroyLobby_success() {
+    void leaveLobby_andDestroyLobby_success() throws NotFoundException {
         // given
         List<Long> emptyList = new ArrayList<>();
         Lobby createdLobby = lobbyService.createLobby(testUser);
@@ -161,7 +161,7 @@ public class LobbyServiceIntegrationTest {
         assertEquals(testUser.getLobby(), createdLobby);
 
         // when:
-        assertThrows(IllegalStateException.class, () -> lobbyService.leaveLobby(createdLobby.getLobbyId(), testUser.getId()));
+        lobbyService.leaveLobby(createdLobby.getLobbyId(), testUser.getId());
         assertTrue(lobbyRepository.findById(createdLobby.getLobbyId()).isEmpty());
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -5,19 +5,24 @@ import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import javassist.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.spy;
 
 
 /**
@@ -43,6 +48,12 @@ public class LobbyServiceIntegrationTest {
     @InjectMocks
     private User testUser;
 
+    @InjectMocks
+    private User testUser2;
+
+    @SpyBean
+    private LobbyService spyLobbyService;
+
     @BeforeEach
     void setup() {
         // given
@@ -59,12 +70,28 @@ public class LobbyServiceIntegrationTest {
         testUser.setWinCount(0);
 
         testUser = userRepository.save(testUser);
+
+        testUser2.setId(2L);
+        testUser2.setUsername("testUsername2");
+        testUser2.setPassword("testPassword");
+        testUser2.setStatus(UserStatus.ONLINE);
+        testUser2.setToken("testToken2");
+        testUser2.setLossCount(0);
+        testUser2.setTieCount(0);
+        testUser2.setWinCount(0);
+
+        testUser2 = userRepository.save(testUser2);
+
+        // MOcking only a single method of the test class
+        spyLobbyService = spy(lobbyService);
+        Mockito.doReturn(1000L).when(spyLobbyService).generateId();
+
     }
 
     @Test
     void createLobby_success() {
         // given:
-        assertNull(lobbyRepository.findByLobbyId(1000L));
+        assertTrue(lobbyRepository.findById(1000L).isEmpty());
 
         // when:
         Lobby createdLobby = lobbyService.createLobby(testUser);
@@ -73,10 +100,28 @@ public class LobbyServiceIntegrationTest {
         assertNotNull(createdLobby.getLobbyId(), "The id of the lobby was not created");
         assertEquals(createdLobby.getLobbyId(), testUser.getLobby().getLobbyId(), "The correct db association was not created");
         assertEquals(createdLobby.getUser().getId(),testUser.getId(), "The correct db association was not created");
+        assertNotNull(lobbyRepository.findById(1000L).get(), "The id of the lobby was not created");
     }
 
     @Test
-    void joinLobby_success() {
+    void joinLobby_success() throws NotFoundException {
+        // given
+        List<Long> emptyList = new ArrayList<>();
+        Lobby createdLobby = lobbyService.createLobby(testUser);
+        assertEquals(emptyList, createdLobby.getUsers());
+
+        // when:
+        lobbyService.joinLobby(createdLobby.getLobbyId(), testUser.getId());
+        List<Long> userIds = new ArrayList<>();
+        userIds.add(1L);
+
+        Optional<Lobby> updatedLobby = lobbyRepository.findById(1000L);
+        assertTrue(updatedLobby.isPresent(), "The id of the lobby was not created");
+        assertEquals(userIds.toString(), updatedLobby.get().getUsers().toString());
+    }
+
+    @Test
+    void leaveLobby_success() throws NotFoundException {
         // given
         List<Long> emptyList = new ArrayList<>();
         Lobby createdLobby = lobbyService.createLobby(testUser);
@@ -85,10 +130,39 @@ public class LobbyServiceIntegrationTest {
         // when:
         createdLobby.addUsers(1L);
         createdLobby.addUsers(2L);
+        lobbyRepository.save(createdLobby);
+        lobbyRepository.flush();
+
         List<Long> userIds = new ArrayList<>();
-        userIds.add(1L);
-        userIds.add(2L);
+        userIds.add(testUser.getId());
+        userIds.add(testUser2.getId());
         assertEquals(createdLobby.getUsers().toString(), userIds.toString());
+
+        lobbyService.leaveLobby(createdLobby.getLobbyId(), testUser2.getId());
+
+        userIds.remove(testUser2.getId());
+        Optional<Lobby> updatedLobby = lobbyRepository.findById(1000L);
+        assertTrue(updatedLobby.isPresent(), "The id of the lobby was not created");
+        assertEquals(updatedLobby.get().getUsers().toString(), userIds.toString());
+
+    }
+
+    @Test
+    void leaveLobby_andDestroyLobby_success() {
+        // given
+        List<Long> emptyList = new ArrayList<>();
+        Lobby createdLobby = lobbyService.createLobby(testUser);
+        assertEquals(emptyList, createdLobby.getUsers());
+
+        createdLobby.addUsers(testUser.getId());
+        lobbyRepository.save(createdLobby);
+        lobbyRepository.flush();
+
+        assertEquals(testUser.getLobby(), createdLobby);
+
+        // when:
+        assertThrows(IllegalStateException.class, () -> lobbyService.leaveLobby(createdLobby.getLobbyId(), testUser.getId()));
+        assertTrue(lobbyRepository.findById(createdLobby.getLobbyId()).isEmpty());
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -42,7 +42,8 @@ public class LobbyServiceTest {
     private User testUser;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
+        // given
         MockitoAnnotations.openMocks(this);
 
         // given
@@ -64,17 +65,27 @@ public class LobbyServiceTest {
     }
 
     @Test
-    public void createLobby_validInputs_success() {
+    void createLobby_validInputs_success() {
 
         Lobby createdLobby = lobbyService.createLobby(testUser);
 
-        Mockito.verify(lobbyRepository, Mockito.times(1)).save(Mockito.any(Lobby.class));
+        Mockito.verify(userRepository, Mockito.times(1)).save(Mockito.any(User.class));
         assertNotNull(createdLobby);
         assertNotNull(createdLobby.getLobbyId());
+        assertNotNull(testUser.getLobby());
     }
 
     @Test
-    public void isFull_true() {
+    void createLobby_alreadyExists_success() {
+
+        Lobby createdLobby = lobbyService.createLobby(testUser);
+        Lobby createdLobby2 = lobbyService.createLobby(testUser);
+
+        assertEquals(createdLobby.getLobbyId(), createdLobby2.getLobbyId());
+    }
+
+    @Test
+    void isFull_true() {
 
         testLobby.addUsers(1L);
         testLobby.addUsers(2L);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -29,7 +29,7 @@ public class LobbyServiceTest {
     @InjectMocks
     private LobbyService lobbyService;
 
-    @InjectMocks
+    @Mock
     private Lobby testLobby;
 
     @Mock
@@ -38,7 +38,7 @@ public class LobbyServiceTest {
     @Mock
     private UserService userService;
 
-    @InjectMocks
+    @Mock
     private User testUser;
 
     @BeforeEach
@@ -204,16 +204,18 @@ public class LobbyServiceTest {
 
     @Test
     public void leaveLobby_validInputs_deleteLobby_success() throws Exception {
+        // given
         testLobby.addUsers(1L);
         testLobby.setUser(testUser);
         testUser.setLobby(testLobby);
+        assertNotNull(testUser.getLobby());
 
         // when -> setup additional mocks for userService and lobbyRepo
         Mockito.when(userService.checkIfUserExists(Mockito.anyLong())).thenReturn(testUser);
         Mockito.when(lobbyRepository.findById(Mockito.any())).thenReturn(Optional.of(testLobby));
+        lobbyService.leaveLobby(testLobby.getLobbyId(), testUser.getId());
 
-        assertThrows(IllegalStateException.class,
-                () -> lobbyService.leaveLobby(testLobby.getLobbyId(), testUser.getId()));
+        assertNull(testUser.getLobby());
 
     }
 
@@ -284,7 +286,7 @@ public class LobbyServiceTest {
 
         lobbyService.deleteLobby(testLobby.getLobbyId(), testUser.getId());
         //assert
-        verify(lobbyRepository, times(1)).delete(testLobby);
+        assertNull(testUser.getLobby());
     }
 
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -159,12 +159,14 @@ public class LobbyServiceTest {
         testLobby.addUsers(3L);
         testLobby.addUsers(4L);
 
+        Long lobbyId = testLobby.getLobbyId();
+
         // when -> setup additional mocks for LobbyRepository and userRepository
         Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
 
         assertThrows(
                 IllegalStateException.class, () -> lobbyService
-                        .joinLobby(testLobby.getLobbyId(), 5L));
+                        .joinLobby(lobbyId, 5L));
 
     }
 
@@ -182,15 +184,16 @@ public class LobbyServiceTest {
     }
 
     @Test
-    public void leaveLobby_NonExistentUser_noSuccess() throws Exception {
+    public void leaveLobby_NonExistentUser_noSuccess()  {
         testLobby.addUsers(1L);
 
+        Long lobbyId = testLobby.getLobbyId();
         // when -> setup additional mocks for LobbyRepository and userRepository
         Mockito.when(lobbyRepository.findByLobbyId(Mockito.any())).thenReturn(testLobby);
 
         assertThrows(
                 NoSuchElementException.class, () -> lobbyService
-                        .leaveLobby(testLobby.getLobbyId(), 2L));
+                        .leaveLobby(lobbyId, 2L));
 
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceTest.java
@@ -263,4 +263,26 @@ public class UserServiceTest {
     Mockito.verify(userRepository, Mockito.times(1)).findAll();
   }
 
+  @Test
+    void getUserById_success() {
+      // given -> a first user has already been created
+      userService.createUser(testUser);
+      Mockito.when(userRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(testUser));
+
+      User returnedUser = userService.getUserById(testUser.getId());
+      assertNotNull(returnedUser, "Returned user should not be null");
+      assertEquals(testUser, returnedUser, "The returned user should match the test user.");
+  }
+
+    @Test
+    void getUserById_throwsException() {
+        // given
+        // no user
+
+
+        //when
+        Mockito.when(userRepository.findById(Mockito.anyLong())).thenReturn(Optional.empty());
+        assertThrows(
+                ResponseStatusException.class, () -> userService.getUserById(1L));
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketServiceTest.java
@@ -1,8 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ public class WebSocketServiceTest {
 
         String status = "subscribed";
 
-        UsersBroadcastJoinNotificationDTO dto = webSocketService.convertToDTO(user.getId(), status);
+        UsersBroadcastNotificationDTO dto = webSocketService.convertToDTO(user.getId(), status);
 
         assertNotNull(dto);
         assertEquals(status, dto.getStatus());
@@ -54,7 +54,7 @@ public class WebSocketServiceTest {
         String msg = "Joined successfully";
         boolean success = true;
 
-        UserJoinNotificationDTO dto = webSocketService.convertToDTO(msg, success);
+        UserNotificationDTO dto = webSocketService.convertToDTO(msg, success);
 
         assertNotNull(dto);
         assertEquals(msg, dto.getMessage());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketServiceTest.java
@@ -2,7 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ public class WebSocketServiceTest {
 
         String status = "subscribed";
 
-        UsersBroadcastNotificationDTO dto = webSocketService.convertToDTO(user.getId(), status);
+        UsersBroadcastJoinNotificationDTO dto = webSocketService.convertToDTO(user.getId(), status);
 
         assertNotNull(dto);
         assertEquals(status, dto.getStatus());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerIntegrationTest.java
@@ -127,7 +127,7 @@ public class WebSocketEventListenerIntegrationTest {
                 doNothing().when(lobbyService).leaveLobby(3000L, 42L);
 
                 doReturn(broadcastDTO)
-                                .when(webSocketService).convertToDTO(42L, "subscribed");
+                                .when(webSocketService).convertToDTO(42L, "unsubscribed");
 
                 doReturn(userDTO)
                                 .when(webSocketService).convertToDTO(anyString(), anyBoolean());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerIntegrationTest.java
@@ -2,7 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.websocket;
 
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.Test;
@@ -57,7 +57,7 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
 
-                UsersBroadcastNotificationDTO LobbyDTO = new UsersBroadcastNotificationDTO();
+                UsersBroadcastJoinNotificationDTO LobbyDTO = new UsersBroadcastJoinNotificationDTO();
                 LobbyDTO.setUsername("username");
                 LobbyDTO.setStatus("subscribed");
 
@@ -87,7 +87,7 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
 
-                UsersBroadcastNotificationDTO LobbyDTO = new UsersBroadcastNotificationDTO();
+                UsersBroadcastJoinNotificationDTO LobbyDTO = new UsersBroadcastJoinNotificationDTO();
                 LobbyDTO.setUsername("username");
                 LobbyDTO.setStatus("subscribed");
 
@@ -116,7 +116,7 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message);
 
-                UsersBroadcastNotificationDTO broadcastDTO = new UsersBroadcastNotificationDTO();
+                UsersBroadcastJoinNotificationDTO broadcastDTO = new UsersBroadcastJoinNotificationDTO();
                 broadcastDTO.setUsername("userX");
                 broadcastDTO.setStatus("subscribed");
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerIntegrationTest.java
@@ -1,8 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.websocket;
 
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.Test;
@@ -57,11 +57,11 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
 
-                UsersBroadcastJoinNotificationDTO LobbyDTO = new UsersBroadcastJoinNotificationDTO();
+                UsersBroadcastNotificationDTO LobbyDTO = new UsersBroadcastNotificationDTO();
                 LobbyDTO.setUsername("username");
                 LobbyDTO.setStatus("subscribed");
 
-                UserJoinNotificationDTO UserDTO = new UserJoinNotificationDTO();
+                UserNotificationDTO UserDTO = new UserNotificationDTO();
                 UserDTO.setMessage("message");
                 UserDTO.setSuccess(true);
 
@@ -87,11 +87,11 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionSubscribeEvent event = new SessionSubscribeEvent(this, message);
 
-                UsersBroadcastJoinNotificationDTO LobbyDTO = new UsersBroadcastJoinNotificationDTO();
+                UsersBroadcastNotificationDTO LobbyDTO = new UsersBroadcastNotificationDTO();
                 LobbyDTO.setUsername("username");
                 LobbyDTO.setStatus("subscribed");
 
-                UserJoinNotificationDTO UserDTO = new UserJoinNotificationDTO();
+                UserNotificationDTO UserDTO = new UserNotificationDTO();
                 UserDTO.setMessage("message");
                 UserDTO.setSuccess(false);
 
@@ -116,11 +116,11 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message);
 
-                UsersBroadcastJoinNotificationDTO broadcastDTO = new UsersBroadcastJoinNotificationDTO();
+                UsersBroadcastNotificationDTO broadcastDTO = new UsersBroadcastNotificationDTO();
                 broadcastDTO.setUsername("userX");
                 broadcastDTO.setStatus("subscribed");
 
-                UserJoinNotificationDTO userDTO = new UserJoinNotificationDTO();
+                UserNotificationDTO userDTO = new UserNotificationDTO();
                 userDTO.setSuccess(true);
                 userDTO.setMessage("Lobby left successfully");
 
@@ -148,7 +148,7 @@ public class WebSocketEventListenerIntegrationTest {
                 Message<byte[]> message = createMessage(destination, sessionAttributes);
                 SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message);
 
-                UserJoinNotificationDTO userDTO = new UserJoinNotificationDTO();
+                UserNotificationDTO userDTO = new UserNotificationDTO();
                 userDTO.setSuccess(false);
                 userDTO.setMessage("oops");
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerTest.java
@@ -20,7 +20,7 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
 import javassist.NotFoundException;
 
 class WebSocketEventListenerTest {
@@ -74,7 +74,7 @@ class WebSocketEventListenerTest {
     @Test
     void handleSubscribeEvent_success() throws Exception {
         SessionSubscribeEvent event = buildSubscribeEvent("/topic/lobby/1234", 55L);
-        UsersBroadcastNotificationDTO broadcastDto = new UsersBroadcastNotificationDTO();
+        UsersBroadcastJoinNotificationDTO broadcastDto = new UsersBroadcastJoinNotificationDTO();
         broadcastDto.setUsername("pippo");
         broadcastDto.setStatus("subscribed");
         UserNotificationDTO userDto = new UserNotificationDTO();
@@ -113,7 +113,7 @@ class WebSocketEventListenerTest {
     @Test
     void handleUnsubscribeEvent_success() throws Exception {
         SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/3000", 88L);
-        UsersBroadcastNotificationDTO broadcastDto = new UsersBroadcastNotificationDTO();
+        UsersBroadcastJoinNotificationDTO broadcastDto = new UsersBroadcastJoinNotificationDTO();
         broadcastDto.setUsername("pluto");
         broadcastDto.setStatus("subscribed");
         UserNotificationDTO userDto = new UserNotificationDTO();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerTest.java
@@ -3,9 +3,7 @@ package ch.uzh.ifi.hase.soprafs24.websocket;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
 
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,8 +18,8 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserJoinNotificationDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastJoinNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UsersBroadcastNotificationDTO;
 import javassist.NotFoundException;
 
 class WebSocketEventListenerTest {
@@ -75,10 +73,10 @@ class WebSocketEventListenerTest {
     @Test
     void handleSubscribeEvent_success() throws Exception {
         SessionSubscribeEvent event = buildSubscribeEvent("/topic/lobby/1234", 55L);
-        UsersBroadcastJoinNotificationDTO broadcastDto = new UsersBroadcastJoinNotificationDTO();
+        UsersBroadcastNotificationDTO broadcastDto = new UsersBroadcastNotificationDTO();
         broadcastDto.setUsername("pippo");
         broadcastDto.setStatus("subscribed");
-        UserJoinNotificationDTO userDto = new UserJoinNotificationDTO();
+        UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("Lobby joined successfully");
         userDto.setSuccess(true);
 
@@ -96,7 +94,7 @@ class WebSocketEventListenerTest {
     @Test
     void handleSubscribeEvent_failure() throws Exception {
         SessionSubscribeEvent event = buildSubscribeEvent("/topic/lobby/2000", 77L);
-        UserJoinNotificationDTO userDto = new UserJoinNotificationDTO();
+        UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("not found");
         userDto.setSuccess(false);
 
@@ -114,10 +112,10 @@ class WebSocketEventListenerTest {
     @Test
     void handleUnsubscribeEvent_success() throws Exception {
         SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/3000", 88L);
-        UsersBroadcastJoinNotificationDTO broadcastDto = new UsersBroadcastJoinNotificationDTO();
+        UsersBroadcastNotificationDTO broadcastDto = new UsersBroadcastNotificationDTO();
         broadcastDto.setUsername("pluto");
         broadcastDto.setStatus("subscribed");
-        UserJoinNotificationDTO userDto = new UserJoinNotificationDTO();
+        UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("Lobby left successfully");
         userDto.setSuccess(true);
 
@@ -135,7 +133,7 @@ class WebSocketEventListenerTest {
     @Test
     void handleUnsubscribeEvent_failure() throws Exception {
         SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/4000", 99L);
-        UserJoinNotificationDTO userDto = new UserJoinNotificationDTO();
+        UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("error!");
         userDto.setSuccess(false);
 


### PR DESCRIPTION
Close #170, close #29, close #171, close #169, close #172, close #174.

- Fix users being nuked deleted by jpa when overwriting lobby
- Change lobby creation behavior when user already has one (it gives back the current one)
- Add REST api to GET specific user
- Add forgotten authentication to GET `users/` endpoint
- If the user already joined a lobby, lobby creation and join now receive back an informative message with the lobby id the use is already in.

It is still a draft because #175 can't be closed yet. I wrote a test to check that the lobby is deleted from the database when the host leave, but it still fail