### PR TITLE
Rematch and quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
 |      ✅     | **/app/playcard**          | **SEND**        | gameId &lt;string&gt;, card &lt;Card&gt;                                                             | Body (JSON)    | Send played card event to server for in-game processing                                             |
 |      ✅     | **/app/chooseCapture**     | **SEND**        | gameId &lt;string&gt;, userId &lt;long&gt;, chosenOption &lt;List{Card}&gt;, playedCard &lt;Card&gt; | Body (JSON)    | Send chosen capture option when multiple options exist                                              |
 |      ✅     | **/app/ai**                | **SEND**        | gameId &lt;string&gt;, userId &lt;long&gt;, requestFlag &lt;string&gt;                               | Body (JSON)    | Send request for AI assistance (hint) to the server                                                 |
-|      ❌     | **/app/rematch**           | **SEND**        | gameId &lt;string&gt;, userId &lt;long&gt;, confirmRematch &lt;boolean&gt;                           | Body (JSON)    | Send rematch confirmation from the player to the server                                             |
-|      ❌     | **/app/quitGame**          | **SEND**        | gameId &lt;string&gt;, userId &lt;long&gt;                                                           | Body (JSON)    | Send quit game request to the server                                                                |
+|      ✅     | **/app/rematch**           | **SEND**        | gameId &lt;string&gt;, userId &lt;long&gt;, confirmRematch &lt;boolean&gt;                           | Body (JSON)    | Send rematch confirmation from the player to the server                                             |
+|      ✅     | **/app/quitGame**          | **SEND**        | gameId &lt;string&gt;, userId &lt;long&gt;                                                           | Body (JSON)    | Send quit game request to the server                                                                |
 |      🚫     | **/game/{gameId}/results** | **SUBSCRIBE**   | gameId &lt;string&gt;                                                                                | Path           | Subscribe to final game results broadcast when the match ends                                       |
 |      ✅     | **/user/queue/reply**      | **SUBSCRIBE**   | --                                                                                                   | --             | Subscribe to private channel for receiving personal notifications (capture options, AI hints, etc.) |
 |      ✅     | **/user/queue/reply**      | **UNSUBSCRIBE** | --                                                                                                   | --             | Unsubscribe from the private channel                                                                |
@@ -94,7 +94,7 @@ so that the client can redirect the user to the right lobby.
 
 ### Lobby deletion
 
-When the host leave the lobby by esplicitly sending an `unsubscribe` request, their lobby is deleted.
+When the host leave the lobby by explicitly sending an `unsubscribe` request, their lobby is deleted.
 
 #### Broadcast to all users in a lobby
 
@@ -112,6 +112,57 @@ The following message is sent to the host of the lobby.
         "success": success <bool>,
         "msg": msg <string>
         }
+
+### Start game
+
+The following message is broadcast to all the participants of this lobby.
+
+        {
+        "success": success <bool>,
+        "msg": msg <string>
+        }
+
+`msg` can be either `"Starting game"` or a string describing the error, e.g. `"Lobby <lobbyId> is not full yet"` or
+`"lobby <lobbyId>: not everyone wants a rematch yet"`
+
+#### Sent to a specific user
+
+The following message is sent to the client who requested a rematch.
+
+        {
+        "success": success <bool>,
+        "msg": msg <string>
+        }
+
+`msg` can be either `"Rematcher has been added to the lobby"` or a string describing the error.
+
+### Rematch
+
+When a user clicks on the rematch button the following messages are sent.
+
+#### Broadcast to all users in a lobby
+
+The following message is broadcast to all the participants of this lobby.
+
+        {
+        "lobbyId": lobbyId <Long>,
+        "hostId": hostId <Long>,
+        "usersIds": List<Long>,
+        "rematchersIds": List<Long>
+        }
+
+`rematchersIds` contains all the user that have selected a rematch.
+
+#### Sent to a specific user
+
+The following message is sent to the client who requested a rematch.
+
+        {
+        "success": success <bool>,
+        "msg": msg <string>
+        }
+
+`msg` can be either `"Rematcher has been added to the lobby"` or a string describing the error.
 
 ## Getting started with Spring Boot
 -   Documentation: https://docs.spring.io/spring-boot/docs/current/reference/html/index.html

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.controller;
 
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.game.GameSession;
 import ch.uzh.ifi.hase.soprafs24.game.Player;
 import ch.uzh.ifi.hase.soprafs24.game.items.Card;
@@ -14,11 +15,10 @@ import ch.uzh.ifi.hase.soprafs24.game.gameDTO.QuitGameResultDTO;
 import ch.uzh.ifi.hase.soprafs24.game.gameDTO.mapper.GameSessionMapper;
 import ch.uzh.ifi.hase.soprafs24.service.GameService;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.UserService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.AiRequestDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.ChosenCaptureDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.PlayCardDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.*;
+import ch.uzh.ifi.hase.soprafs24.websocket.mapper.wsDTOMapper;
 import javassist.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,11 +39,13 @@ public class MessageController {
     private final LobbyService lobbyService;
     private final GameService gameService;
     private final WebSocketService webSocketService;
+    private final UserService userService;
 
-    public MessageController(LobbyService lobbyService, GameService gameService, WebSocketService webSocketService) {
+    public MessageController(LobbyService lobbyService, GameService gameService, WebSocketService webSocketService, UserService userService) {
         this.lobbyService = lobbyService;
         this.gameService = gameService;
         this.webSocketService = webSocketService;
+        this.userService = userService;
     }
 
     @MessageMapping("/startGame/{lobbyId}")
@@ -56,7 +58,14 @@ public class MessageController {
             if (!lobbyService.lobbyIsFull(lobbyId)) {
                 throw new IllegalArgumentException("Lobby " + lobbyId + " is not full yet");
             }
+            // check if everyone already clicked rematch
+            if (!lobbyService.rematchIsFull(lobbyId)) {
+                throw new IllegalArgumentException(String.format("lobby %d: not everyone wants a rematch yet", lobbyId));
+            }
             gameService.startGame(lobby);
+            // reset rematch array
+            lobbyService.resetRematch(lobbyId);
+
         } catch (Exception e) {
             log.error(e.getMessage());
             msg = "Error starting game: " + e.getMessage();
@@ -177,7 +186,30 @@ public class MessageController {
             webSocketService.lobbyNotifications(result.getUserId(), result);
         }
 
-        lobbyService.deleteLobby(gameId);
+    @MessageMapping("/rematch")
+    public void rematch(StompHeaderAccessor headerAccessor)  throws NotFoundException {
+        Object userIdObj = Objects.requireNonNull(headerAccessor.getSessionAttributes())
+                .get("userId");
+        Long userId = (Long) userIdObj;
+        User user = userService.checkIfUserExists(userId);
+        Long lobbyId = user.getLobbyJoined();
+        Lobby lobby = lobbyService.getLobbyById(lobbyId);
+
+        boolean success = true;
+        String msg = "Rematcher has been added to the lobby";
+
+        try {
+            lobbyService.addRematcher(userId, lobbyId);
+        }
+        catch (NotFoundException e) {
+            success = false;
+            msg = e.getMessage();
+        }
+        UserNotificationDTO privateDTO = webSocketService.convertToDTO(msg, success);
+        webSocketService.lobbyNotifications(userId, privateDTO);
+
+        wsLobbyDTO broadcastDTO = wsDTOMapper.INSTANCE.convertLobbyTowsLobbyRematchDTO(lobby);
+        webSocketService.broadCastLobbyNotifications(lobbyId, broadcastDTO);
     }
 
-}
+    }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
@@ -192,7 +192,7 @@ public class MessageController {
         }
 
         // default msg and status
-        String msg = String.format("The lobby with id %s has been deleted", lobbyId);
+        String msg = String.format("Lobby with id %s has been deleted", lobbyId);
         boolean success = true;
         try {
             lobbyService.deleteLobby(lobbyId);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Lobby.java
@@ -1,6 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
 import ch.uzh.ifi.hase.soprafs24.game.GameSession;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Fetch;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +21,12 @@ public class Lobby implements Serializable {
 
 
     @ElementCollection(fetch = FetchType.EAGER)
+    @Fetch(FetchMode.SUBSELECT)
     private List<Long> users = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Fetch(FetchMode.SUBSELECT)
+    private List<Long> rematchers = new ArrayList<>();
 
     @Transient
     private GameSession gameSession;
@@ -37,6 +44,14 @@ public class Lobby implements Serializable {
     public void addUsers(Long userId) {users.add(userId);}
 
     public boolean removeUsers(Long userId) {return users.remove(userId);}
+
+    public List<Long> getRematchers() {return rematchers;}
+
+    public void adddRematchers(Long userId) {rematchers.add(userId);}
+
+    public boolean removeRematchers(Long userId){return rematchers.remove(userId);}
+
+    public void clearRematchers() {rematchers.clear();}
 
     public GameSession getGameSession() {return gameSession;}
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -126,13 +126,8 @@ public class LobbyService {
     }
 
     public boolean lobbyIsFull(Long lobbyId) throws NotFoundException {
-        // TODO refactor to use checkIfLobbyExists
-        Optional<Lobby> lobby = lobbyRepository.findById(lobbyId);
-        if (lobby.isEmpty()) {
-            String msg = "No lobby with id " + lobbyId;
-            throw new NotFoundException(msg);
-        }
-        return lobby.get().getUsers().size() >= 4;
+        Lobby lobby = checkIfLobbyExists(lobbyId);
+        return lobby.getUsers().size() >= 4;
     }
 
     public Lobby checkIfLobbyExists(Long lobbyId) throws NotFoundException {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -83,6 +83,7 @@ public class LobbyService {
         if (!lobby.getUsers().contains(userId)) {
             lobby.addUsers(userId);
             user.setLobbyJoined(lobbyId);
+            lobby.adddRematchers(userId);
         }
         userRepository.save(user);
         userRepository.flush();
@@ -95,6 +96,7 @@ public class LobbyService {
         if (lobby.getUser() != null && lobby.getUser().getId().equals(userId)) {
             user.setLobby(null);
             user.setLobbyJoined(null);
+            lobby.removeRematchers(userId);
             userRepository.save(user);
             userRepository.flush();
 
@@ -112,6 +114,7 @@ public class LobbyService {
 
 
         lobby.removeUsers(userId);
+        lobby.removeRematchers(userId);
         user.setLobbyJoined(null);
 
 
@@ -123,6 +126,7 @@ public class LobbyService {
     }
 
     public boolean lobbyIsFull(Long lobbyId) throws NotFoundException {
+        // TODO refactor to use checkIfLobbyExists
         Optional<Lobby> lobby = lobbyRepository.findById(lobbyId);
         if (lobby.isEmpty()) {
             String msg = "No lobby with id " + lobbyId;
@@ -170,6 +174,23 @@ public class LobbyService {
         } catch (EmptyResultDataAccessException e) {
             log.info("Lobby with id {} was already deleted (ignored)", lobby.getLobbyId());
         }
+    }
+
+    public boolean rematchIsFull(Long lobbyId) throws NotFoundException {
+       Lobby lobby = checkIfLobbyExists(lobbyId);
+       // TODO illegalstateException if more than 4 user
+        return lobby.getRematchers().size() >= 4;
+    }
+
+    public void resetRematch(Long lobbyId) throws NotFoundException {
+        Lobby lobby = checkIfLobbyExists(lobbyId);
+        lobby.clearRematchers();
+    }
+
+    public void addRematcher(Long lobbyId, Long userId) throws NotFoundException {
+        Lobby lobby = checkIfLobbyExists(lobbyId);
+        userService.checkIfUserExists(userId);
+        lobby.adddRematchers(userId);
     }
 
     public Long generateId() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -89,13 +89,13 @@ public class UserService {
 
     // TODO eventually refactor better to avoid duplicate code
     public User checkIfUserExists(long userId) throws NotFoundException {
-      User user = userRepository.findById(userId).orElse(null);
+      Optional<User> user = userRepository.findById(userId);
 
-      if(user == null) {
+      if(user.isEmpty()) {
           String msg = "User with id " + userId + " does not exist";
           throw new NotFoundException(msg);
       }
-      return user;
+      return user.get();
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/wsLobbyDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/DTO/wsLobbyDTO.java
@@ -10,6 +10,8 @@ public class wsLobbyDTO {
 
     private List<Long> usersIds;
 
+    private List<Long> rematchersIds;
+
     public Long getLobbyId() {return lobbyId;}
 
     public void setLobbyId(Long lobbyId) {this.lobbyId = lobbyId;}
@@ -21,4 +23,8 @@ public class wsLobbyDTO {
     public List<Long> getUsersIds() {return usersIds;}
 
     public void setUsersIds(List<Long> usersIds) {this.usersIds = usersIds;}
+
+    public List<Long> getRematchersIds() {return rematchersIds;}
+
+    public void setRematchersIds(List<Long> rematchersIds) {this.rematchersIds = rematchersIds;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/mapper/wsDTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/mapper/wsDTOMapper.java
@@ -16,10 +16,17 @@ public interface wsDTOMapper {
     @Mapping(source = "lobbyId", target = "lobbyId")
     @Mapping(source = "user", target = "hostId", qualifiedByName = "getUserId")
     @Mapping(source = "users", target = "usersIds")
+    @Mapping(target = "rematchersIds", ignore = true)
     wsLobbyDTO convertLobbyTowsLobbyDTO(Lobby lobby);
 
+    @Mapping(source = "lobbyId", target = "lobbyId")
+    @Mapping(source = "user", target = "hostId", qualifiedByName = "getUserId")
+    @Mapping(source = "users", target = "usersIds")
+    @Mapping(source = "rematchers", target = "rematchersIds")
+    wsLobbyDTO convertLobbyTowsLobbyRematchDTO(Lobby lobby);
+
     @Named("getUserId")
-    static Long getUserid(User user) {
+    static Long getUserId(User user) {
         return user.getId();
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.game.GameSession;
 import ch.uzh.ifi.hase.soprafs24.game.Player;
 import ch.uzh.ifi.hase.soprafs24.game.gameDTO.CardDTO;
@@ -14,10 +15,10 @@ import ch.uzh.ifi.hase.soprafs24.game.gameDTO.QuitGameResultDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyDTO;
 import ch.uzh.ifi.hase.soprafs24.service.GameService;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.UserService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.ChosenCaptureDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.PlayCardDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.UserNotificationDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.DTO.*;
+import ch.uzh.ifi.hase.soprafs24.websocket.mapper.wsDTOMapper;
 import javassist.NotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +28,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.util.Pair;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import ch.uzh.ifi.hase.soprafs24.game.gameDTO.AISuggestionDTO;
-import ch.uzh.ifi.hase.soprafs24.websocket.DTO.AiRequestDTO;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +44,13 @@ public class MessageControllerTest {
     private GameService gameService;
 
     @Mock
+    private UserService userService;
+
+    @Mock
     private WebSocketService webSocketService;
+
+    @Mock
+    private wsDTOMapper wsDTOMapper;
 
     @InjectMocks
     private MessageController messageController;
@@ -75,11 +81,14 @@ public class MessageControllerTest {
 
         when(lobbyService.getLobbyById(100L)).thenReturn(lobby);
         when(lobbyService.lobbyIsFull(lobby.getLobbyId())).thenReturn(true);
+        when(lobbyService.rematchIsFull(lobby.getLobbyId())).thenReturn(true);
         when(gameService.startGame(lobby)).thenReturn(dummyGame);
         when(webSocketService.convertToDTO(anyString(), anyBoolean())).thenReturn(dummyNotificationDTO);
 
         messageController.processStartGame(lobbyDTO.getLobbyId());
 
+        verify(gameService, times(1)).startGame(lobby);
+        verify(lobbyService, times(1)).resetRematch(lobby.getLobbyId());
         verify(webSocketService, times(1))
                 .convertToDTO(msg, true);
         verify(webSocketService, times(1))
@@ -107,6 +116,38 @@ public class MessageControllerTest {
 
         messageController.processStartGame(lobbyDTO.getLobbyId());
 
+        verify(gameService, never()).startGame(lobby);
+        verify(lobbyService, never()).resetRematch(lobby.getLobbyId());
+        verify(webSocketService, times(1))
+                .convertToDTO("Error starting game: " + msg, false);
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(eq(100L), any(UserNotificationDTO.class));
+    }
+
+    @Test
+    void testProcessStartGameRematchThrowsException() throws NotFoundException {
+        // given
+        LobbyDTO lobbyDTO = new LobbyDTO();
+        lobbyDTO.setLobbyId(100L);
+
+        Lobby lobby = new Lobby();
+        lobby.setLobbyId(100L);
+
+        String msg = String.format("lobby %d: not everyone wants a rematch yet", lobby.getLobbyId());
+        UserNotificationDTO dummyNotificationDTO = new UserNotificationDTO();
+        dummyNotificationDTO.setSuccess(Boolean.FALSE);
+        dummyNotificationDTO.setMessage(msg);
+
+        // when
+        when(lobbyService.getLobbyById(100L)).thenReturn(lobby);
+        when(lobbyService.lobbyIsFull(lobby.getLobbyId())).thenReturn(true);
+        when(lobbyService.rematchIsFull(lobby.getLobbyId())).thenReturn(false);
+        when(webSocketService.convertToDTO(anyString(), anyBoolean())).thenReturn(dummyNotificationDTO);
+
+        messageController.processStartGame(lobbyDTO.getLobbyId());
+
+        verify(gameService, never()).startGame(lobby);
+        verify(lobbyService, never()).resetRematch(lobby.getLobbyId());
         verify(webSocketService, times(1))
                 .convertToDTO("Error starting game: " + msg, false);
         verify(webSocketService, times(1))
@@ -158,14 +199,14 @@ public class MessageControllerTest {
     @Test
     public void testProcessChooseCapture() {
         Lobby lobby = new Lobby();
-        lobby.setLobbyId(400L);
+        lobby.setLobbyId(4000L);
         lobby.addUsers(10L);
         lobby.addUsers(20L);
-        GameSession session = new GameSession(400L, new ArrayList<>(lobby.getUsers()));
-        when(gameService.getGameSessionById(400L)).thenReturn(session);
+        GameSession session = new GameSession(4000L, new ArrayList<>(lobby.getUsers()));
+        when(gameService.getGameSessionById(4000L)).thenReturn(session);
 
         ChosenCaptureDTO chosenCaptureDTO = new ChosenCaptureDTO();
-        chosenCaptureDTO.setGameId(400L);
+        chosenCaptureDTO.setGameId(4000L);
         List<CardDTO> chosenOption = new ArrayList<>();
         chosenOption.add(new CardDTO("COPPE", 3));
         chosenOption.add(new CardDTO("COPPE", 4));
@@ -175,7 +216,7 @@ public class MessageControllerTest {
 
         messageController.processChooseCapture(chosenCaptureDTO, accessor);
 
-        verify(webSocketService, atLeastOnce()).broadCastLobbyNotifications(eq(400L), any());
+        verify(webSocketService, atLeastOnce()).broadCastLobbyNotifications(eq(4000L), any());
         verify(webSocketService, atLeastOnce()).lobbyNotifications(eq(10L), any());
     }
 
@@ -198,10 +239,14 @@ public class MessageControllerTest {
 
     // --- Test /app/quit ---
     @Test
-    public void testProcessQuitGame() throws Exception {
+    void testProcessQuitGame() throws Exception {
         // Given
         Long quittingUserId = 5L;
-        Long gameId = 10L;
+        User testUser = new User();
+        testUser.setId(quittingUserId);
+        testUser.setLobbyJoined(4000L);
+        Long gameId = 4000L;
+        GameSession game = new GameSession(gameId, new ArrayList<>());
         StompHeaderAccessor accessor = createHeaderAccessorWithUser(quittingUserId);
 
         QuitGameDTO dto = new QuitGameDTO();
@@ -219,7 +264,21 @@ public class MessageControllerTest {
 
         List<QuitGameResultDTO> results = Arrays.asList(r1, r2);
 
+
+        String msg = "The lobby with id 4000 has been deleted";
+
+        BroadcastNotificationDTO broadcastDTO = new BroadcastNotificationDTO();
+        broadcastDTO.setMessage(msg);
+
+        UserNotificationDTO privateDTO = new UserNotificationDTO();
+        privateDTO.setMessage(msg);
+        privateDTO.setSuccess(Boolean.TRUE);
+
         when(gameService.quitGame(gameId, quittingUserId)).thenReturn(results);
+        when(userService.checkIfUserExists(anyLong())).thenReturn(testUser);
+        when(gameService.getGameSessionById(4000L)).thenReturn(game);
+        when(webSocketService.convertToDTO(anyString())).thenReturn(broadcastDTO);
+        when(webSocketService.convertToDTO(msg, true)).thenReturn(privateDTO);
 
         messageController.processQuitGame(dto, accessor);
 
@@ -229,6 +288,189 @@ public class MessageControllerTest {
                 .lobbyNotifications(eq(8L), eq(r2));
 
         verify(lobbyService, times(1)).deleteLobby(gameId);
+
+        verify(webSocketService, times(1))
+                .convertToDTO(msg);
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(BroadcastNotificationDTO.class));
+        verify(webSocketService, times(1))
+                .convertToDTO(msg, true);
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(UserNotificationDTO.class));
+    }
+
+    @Test
+    void testProcessQuit() throws Exception {
+        // Given
+        Long quittingUserId = 5L;
+        User testUser = new User();
+        testUser.setId(quittingUserId);
+        testUser.setLobbyJoined(4000L);
+        Long gameId = 4000L;
+        GameSession game = new GameSession(gameId, new ArrayList<>());
+        StompHeaderAccessor accessor = createHeaderAccessorWithUser(quittingUserId);
+
+        QuitGameDTO dto = new QuitGameDTO();
+        dto.setGameId(gameId);
+
+        String msg = "The lobby with id 4000 has been deleted";
+
+        BroadcastNotificationDTO broadcastDTO = new BroadcastNotificationDTO();
+        broadcastDTO.setMessage(msg);
+
+        UserNotificationDTO privateDTO = new UserNotificationDTO();
+        privateDTO.setMessage(msg);
+        privateDTO.setSuccess(Boolean.TRUE);
+
+
+        // when
+        when(userService.checkIfUserExists(anyLong())).thenReturn(testUser);
+        when(gameService.getGameSessionById(anyLong())).thenReturn(null);
+        when(webSocketService.convertToDTO(anyString())).thenReturn(broadcastDTO);
+        when(webSocketService.convertToDTO(msg, true)).thenReturn(privateDTO);
+
+        messageController.processQuitGame(dto, accessor);
+
+        verify(gameService, never()).quitGame(anyLong(), anyLong());
+        verify(lobbyService, times(1)).deleteLobby(gameId);
+        verify(webSocketService, times(1))
+                .convertToDTO(msg);
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(BroadcastNotificationDTO.class));
+        verify(webSocketService, times(1))
+                .convertToDTO(msg, true);
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(UserNotificationDTO.class));
+    }
+
+    @Test
+    void testProcessQuitThrowsException() throws Exception {
+        // Given
+        Long quittingUserId = 5L;
+        User testUser = new User();
+        testUser.setId(quittingUserId);
+        testUser.setLobbyJoined(4000L);
+        Long gameId = 4000L;
+        GameSession game = new GameSession(gameId, new ArrayList<>());
+        StompHeaderAccessor accessor = createHeaderAccessorWithUser(quittingUserId);
+
+        QuitGameDTO dto = new QuitGameDTO();
+        dto.setGameId(gameId);
+
+        String msg = "The lobby with id 4000 was not found";
+
+        BroadcastNotificationDTO broadcastDTO = new BroadcastNotificationDTO();
+        broadcastDTO.setMessage(msg);
+
+        UserNotificationDTO privateDTO = new UserNotificationDTO();
+        privateDTO.setMessage(msg);
+        privateDTO.setSuccess(Boolean.TRUE);
+
+
+        // when
+        when(userService.checkIfUserExists(anyLong())).thenReturn(testUser);
+        doThrow(new NotFoundException(msg))
+                .when(lobbyService).deleteLobby(gameId);
+        when(gameService.getGameSessionById(anyLong())).thenReturn(null);
+        when(webSocketService.convertToDTO(msg, false)).thenReturn(privateDTO);
+
+        messageController.processQuitGame(dto, accessor);
+
+        verify(gameService, never()).quitGame(anyLong(), anyLong());
+        verify(lobbyService, times(1)).deleteLobby(gameId);
+        verify(webSocketService, never())
+                .convertToDTO(msg);
+        verify(webSocketService, never())
+                .broadCastLobbyNotifications(anyLong(), any(BroadcastNotificationDTO.class));
+        verify(webSocketService, times(1))
+                .convertToDTO(msg, false);
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(UserNotificationDTO.class));
+    }
+
+    @Test
+    void testRematchSuccess() throws NotFoundException {
+        // given
+        Long userId = 1L;
+        User testUser = new User();
+        testUser.setId(userId);
+        testUser.setLobbyJoined(1000L);
+
+        Long lobbyId = 1000L;
+        Lobby testLobby = new Lobby();
+        testLobby.setLobbyId(lobbyId);
+        testLobby.setUser(testUser);
+
+        wsLobbyDTO lobbyDTO = new wsLobbyDTO();
+        lobbyDTO.setLobbyId(lobbyId);
+        lobbyDTO.setHostId(userId);
+
+        UserNotificationDTO privateDTO = new UserNotificationDTO();
+        privateDTO.setSuccess(true);
+        privateDTO.setMessage("Rematcher has been added to the lobby");
+
+
+        StompHeaderAccessor accessor = createHeaderAccessorWithUser(userId);
+
+        when(userService.checkIfUserExists(anyLong())).thenReturn(testUser);
+        when(lobbyService.getLobbyById(lobbyId)).thenReturn(testLobby);
+        when(webSocketService.convertToDTO(anyString(), anyBoolean())).thenReturn(privateDTO);
+
+        messageController.rematch(accessor);
+
+        // verify
+        verify(lobbyService, times(1))
+                .addRematcher(anyLong(), anyLong());
+        verify(webSocketService, times(1))
+                .convertToDTO(anyString(), anyBoolean());
+        verify(webSocketService, times(1))
+                .lobbyNotifications(eq(userId), eq(privateDTO));
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(wsLobbyDTO.class));
+
+    }
+
+    @Test
+    void testRematchNotFound() throws NotFoundException {
+        // given
+        Long userId = 1L;
+        User testUser = new User();
+        testUser.setId(userId);
+        testUser.setLobbyJoined(1000L);
+
+        Long lobbyId = 1000L;
+        Lobby testLobby = new Lobby();
+        testLobby.setLobbyId(lobbyId);
+        testLobby.setUser(testUser);
+
+        wsLobbyDTO lobbyDTO = new wsLobbyDTO();
+        lobbyDTO.setLobbyId(lobbyId);
+        lobbyDTO.setHostId(userId);
+
+        UserNotificationDTO privateDTO = new UserNotificationDTO();
+        privateDTO.setSuccess(false);
+        privateDTO.setMessage("No lobby with id 1000L found");
+
+
+        StompHeaderAccessor accessor = createHeaderAccessorWithUser(userId);
+
+        when(userService.checkIfUserExists(anyLong())).thenReturn(testUser);
+        when(lobbyService.getLobbyById(lobbyId)).thenReturn(testLobby);
+        doThrow(new NotFoundException("No lobby with id 1000L found")).when(lobbyService).addRematcher(anyLong(), anyLong());
+        when(webSocketService.convertToDTO(anyString(), anyBoolean())).thenReturn(privateDTO);
+
+        messageController.rematch(accessor);
+
+        // verify
+        verify(lobbyService, times(1))
+                .addRematcher(anyLong(), anyLong());
+        verify(webSocketService, times(1))
+                .convertToDTO(anyString(), anyBoolean());
+        verify(webSocketService, times(1))
+                .lobbyNotifications(eq(userId), eq(privateDTO));
+        verify(webSocketService, times(1))
+                .broadCastLobbyNotifications(anyLong(), any(wsLobbyDTO.class));
+
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
@@ -265,7 +265,7 @@ public class MessageControllerTest {
         List<QuitGameResultDTO> results = Arrays.asList(r1, r2);
 
 
-        String msg = "The lobby with id 4000 has been deleted";
+        String msg = "Lobby with id 4000 has been deleted";
 
         BroadcastNotificationDTO broadcastDTO = new BroadcastNotificationDTO();
         broadcastDTO.setMessage(msg);
@@ -313,7 +313,7 @@ public class MessageControllerTest {
         QuitGameDTO dto = new QuitGameDTO();
         dto.setGameId(gameId);
 
-        String msg = "The lobby with id 4000 has been deleted";
+        String msg = "Lobby with id 4000 has been deleted";
 
         BroadcastNotificationDTO broadcastDTO = new BroadcastNotificationDTO();
         broadcastDTO.setMessage(msg);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -93,6 +95,7 @@ public class LobbyServiceIntegrationTest {
 
         // given
         assertTrue(created.getUsers().isEmpty());
+        assertTrue(created.getRematchers().isEmpty());
 
         // when
         lobbyService.joinLobby(id, testUser.getId());
@@ -102,6 +105,7 @@ public class LobbyServiceIntegrationTest {
         assertTrue(updated.isPresent());
         assertEquals(1, updated.get().getUsers().size());
         assertEquals(testUser.getId(), updated.get().getUsers().get(0));
+        assertEquals(testUser.getId(), updated.get().getRematchers().get(0));
     }
 
     @Test
@@ -111,8 +115,13 @@ public class LobbyServiceIntegrationTest {
 
         created.addUsers(testUser.getId());
         created.addUsers(testUser2.getId());
+        created.adddRematchers(testUser.getId());
+        created.adddRematchers(testUser2.getId());
         lobbyRepository.save(created);
         lobbyRepository.flush();
+
+        List<Long> users = new ArrayList<>();
+        users.add(testUser.getId());
 
         // when
         lobbyService.leaveLobby(id, testUser2.getId());
@@ -121,7 +130,8 @@ public class LobbyServiceIntegrationTest {
         Optional<Lobby> updated = lobbyRepository.findById(id);
         assertTrue(updated.isPresent());
         assertEquals(1, updated.get().getUsers().size());
-        assertEquals(testUser.getId(), updated.get().getUsers().get(0));
+        assertEquals(users, updated.get().getUsers());
+        assertEquals(testUser.getId(), updated.get().getRematchers().get(0));
     }
 
     @Test


### PR DESCRIPTION
Close #123, close #124, close #125

- Add quit functionality to `/quitGame` endpoint, #124 
- Add rematch endpoint and logic to check if rematch is possible before game start, #123, #125
- Add `rematchers` collection of user ids in the db, modify `fetchmode` to fix Hibernate exception, #123, #125
- Add and update tests
- Update readme