### PR TITLE
Listener fix and minor joinLobby fix

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 
@@ -67,15 +68,16 @@ public class LobbyService {
         Lobby lobby = checkIfLobbyExists(lobbyId);
         User user = userService.checkIfUserExists(userId);
 
-        // check if lobby is already full
-        if (lobbyIsFull(lobbyId)) {
-            String msg = "The lobby is already full";
+        //TODO refactor this and next if block
+        // check if user is already in another lobby
+        if (user.getLobbyJoined() != null && !Objects.equals(user.getLobbyJoined(), lobbyId)) {
+            String msg = "User with id " + user.getId() + " already joined lobby " + user.getLobbyJoined();
             throw new IllegalStateException(msg);
         }
 
-        // check if user is already in another lobby
-        if (user.getLobbyJoined() != null) {
-            String msg = "User with id " + user.getId() + " already joined lobby " + user.getLobbyJoined();
+        // check if lobby is already full
+        if (lobbyIsFull(lobbyId)) {
+            String msg = "The lobby is already full";
             throw new IllegalStateException(msg);
         }
 
@@ -121,6 +123,7 @@ public class LobbyService {
         userRepository.save(user);
     }
 
+    // TODO refactor this unnecessary method
     public Lobby getLobbyById(Long lobbyId) throws NotFoundException {
         return checkIfLobbyExists(lobbyId);
     }
@@ -193,6 +196,8 @@ public class LobbyService {
         return user.getLobbyJoined();
     }
 
+
+    //TODO set private
     public Long generateId() {
         Long randomId;
         do {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -188,6 +188,11 @@ public class LobbyService {
         lobby.adddRematchers(userId);
     }
 
+    public Long getLobbyIdByParticipantId(Long participantId) throws NotFoundException {
+        User user = userService.checkIfUserExists(participantId);
+        return user.getLobbyJoined();
+    }
+
     public Long generateId() {
         Long randomId;
         do {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/WebSocketService.java
@@ -35,6 +35,7 @@ public class WebSocketService {
         messagingTemplate.convertAndSend("/topic/lobby/" + lobbyId, DTO);
     }
 
+    // TODO refactor rename method
     // sent (join) notification back to specific user
     public void lobbyNotifications(Long userId, Object DTO) {
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -147,5 +147,8 @@ public class LobbyServiceIntegrationTest {
         lobbyService.leaveLobby(id, testUser.getId());
 
         assertFalse(lobbyRepository.existsById(id), "Lobby has not been deleted");
+
+        // check that the db has not nuked the host too
+        assertTrue(userRepository.existsById(testUser.getId()));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -63,6 +63,7 @@ public class LobbyServiceTest {
         // when -> any object is being saved in the userRepository -> return the dummy
         // testLobby
         Mockito.when(lobbyRepository.save(Mockito.any())).thenReturn(testLobby);
+        Mockito.when(userRepository.save(Mockito.any())).thenReturn(testUser);
     }
 
     @Test
@@ -262,7 +263,7 @@ public class LobbyServiceTest {
     }
 
     @Test
-    public void getLobbyById_notExists_throwsNoSuchElementException() {
+    void getLobbyById_notExists_throwsNoTFoundException() {
         when(lobbyRepository.findById(123L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
@@ -395,6 +396,29 @@ public class LobbyServiceTest {
         //assert
         assertThrows(NotFoundException.class,
                 () -> lobbyService.addRematcher(testLobby.getLobbyId(), testUser.getId()));
+    }
+
+    @Test
+    void getLobbyByParticipantId_validInputs_success() throws NotFoundException {
+        // given
+        testUser.setLobbyJoined(1000L);
+        // when
+        when(userService.checkIfUserExists(anyLong())).thenReturn(testUser);
+        Long lobbyId = lobbyService.getLobbyIdByParticipantId(testUser.getId());
+        // then
+        assertEquals(1000L, lobbyId);
+    }
+
+    @Test
+    void getLobbyByParticipantId_nonExistingUser_throwsException() throws NotFoundException {
+        // given
+        testUser.setLobbyJoined(1000L);
+        // when
+        when(userService.checkIfUserExists(anyLong())).thenThrow(new NotFoundException(("error")));
+
+        //assert
+        assertThrows(NotFoundException.class,
+                () -> lobbyService.getLobbyIdByParticipantId(testUser.getId()));
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -178,7 +178,7 @@ public class LobbyServiceTest {
     }
 
     @Test
-    public void joinLobby_full_noSuccess() {
+    void joinLobby_full_noSuccess() throws NotFoundException {
         testLobby.addUsers(1L);
         testLobby.addUsers(2L);
         testLobby.addUsers(3L);
@@ -188,6 +188,7 @@ public class LobbyServiceTest {
 
         // when -> setup additional mocks for LobbyRepository and userRepository
         Mockito.when(lobbyRepository.findById(Mockito.any())).thenReturn(Optional.of(testLobby));
+        when(userService.checkIfUserExists(Mockito.anyLong())).thenReturn(testUser);
 
         assertThrows(
                 IllegalStateException.class, () -> lobbyService

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListenerTest.java
@@ -58,12 +58,11 @@ class WebSocketEventListenerTest {
         return new SessionSubscribeEvent(this, message);
     }
 
-    private SessionUnsubscribeEvent buildUnsubscribeEvent(String destination, Long userId) {
+    private SessionUnsubscribeEvent buildUnsubscribeEvent(Long userId) {
         Map<String, Object> sessionAttrs = new HashMap<>();
         sessionAttrs.put("userId", userId);
 
         Map<String, Object> headers = new HashMap<>();
-        headers.put("simpDestination", destination);
         headers.put("simpSessionAttributes", sessionAttrs);
 
         Message<byte[]> message = new GenericMessage<>(
@@ -113,16 +112,19 @@ class WebSocketEventListenerTest {
 
     @Test
     void handleUnsubscribeEvent_success() throws Exception {
-        SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/3000", 88L);
+        SessionUnsubscribeEvent event = buildUnsubscribeEvent(88L);
         UsersBroadcastJoinNotificationDTO broadcastDto = new UsersBroadcastJoinNotificationDTO();
         broadcastDto.setUsername("pluto");
         broadcastDto.setStatus("subscribed");
         UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("Lobby left successfully");
         userDto.setSuccess(true);
+        Long lobbyId = 3000L;
         Lobby lobby = new Lobby();
+        lobby.setLobbyId(lobbyId);
 
         doNothing().when(lobbyService).leaveLobby(3000L, 88L);
+        when(lobbyService.getLobbyIdByParticipantId(88L)).thenReturn(lobbyId);
         when(webSocketService.convertToDTO(88L, 3000L,"unsubscribed")).thenReturn(broadcastDto);
         when(webSocketService.convertToDTO("Lobby left successfully", true)).thenReturn(userDto);
         when(lobbyService.checkIfLobbyExists(anyLong())).thenReturn(lobby);
@@ -136,7 +138,7 @@ class WebSocketEventListenerTest {
 
     @Test
     void handleUnsubscribeEvent_lobbyDeletion_success() throws Exception {
-        SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/3000", 88L);
+        SessionUnsubscribeEvent event = buildUnsubscribeEvent(88L);
 
         UsersBroadcastJoinNotificationDTO broadcastDtoUnsubscribe = new UsersBroadcastJoinNotificationDTO();
         broadcastDtoUnsubscribe.setUsername("pluto");
@@ -149,7 +151,10 @@ class WebSocketEventListenerTest {
         userDto.setMessage("Lobby deleted successfully");
         userDto.setSuccess(true);
 
+        Long lobbyId = 3000L;
+
         doNothing().when(lobbyService).leaveLobby(3000L, 88L);
+        when(lobbyService.getLobbyIdByParticipantId(88L)).thenReturn(lobbyId);
         when(lobbyService.checkIfLobbyExists(anyLong())).thenThrow(new NotFoundException("not found"));
         when(webSocketService.convertToDTO("Lobby with id 3000 has been deleted")).thenReturn(broadcastDto);
         when(webSocketService.convertToDTO("Lobby deleted successfully", true)).thenReturn(userDto);
@@ -165,14 +170,17 @@ class WebSocketEventListenerTest {
 
     @Test
     void handleUnsubscribeEvent_lobbyDeletion_failure() throws Exception {
-        SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/3000", 88L);
+        SessionUnsubscribeEvent event = buildUnsubscribeEvent(88L);
 
         UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("No lobby with id <lobbyId> found");
         userDto.setSuccess(false);
 
+        Long lobbyId = 3000L;
         Lobby lobby = new Lobby();
+        lobby.setLobbyId(lobbyId);
 
+        when(lobbyService.getLobbyIdByParticipantId(88L)).thenReturn(lobbyId);
         doThrow(new NotFoundException("No lobby with id <lobbyId> found")).when(lobbyService).leaveLobby(3000L, 88L);
         when(webSocketService.convertToDTO("No lobby with id <lobbyId> found", false)).thenReturn(userDto);
         when(lobbyService.checkIfLobbyExists(anyLong())).thenReturn(lobby);
@@ -185,14 +193,16 @@ class WebSocketEventListenerTest {
     }
 
     @Test
-    void handleUnsubscribeEvent_failure() throws Exception {
-        SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/lobby/4000", 99L);
+    void handleUnsubscribeEventLobbyNotFound_failure() throws Exception {
+        SessionUnsubscribeEvent event = buildUnsubscribeEvent(99L);
         UserNotificationDTO userDto = new UserNotificationDTO();
         userDto.setMessage("error!");
         userDto.setSuccess(false);
-
+        Long lobbyId = 4000L;
         Lobby lobby = new Lobby();
+        lobby.setLobbyId(lobbyId);
 
+        when(lobbyService.getLobbyIdByParticipantId(99L)).thenReturn(lobbyId);
         doThrow(new NotFoundException("error!"))
                 .when(lobbyService).leaveLobby(4000L, 99L);
         when(webSocketService.convertToDTO("error!", false)).thenReturn(userDto);
@@ -213,9 +223,24 @@ class WebSocketEventListenerTest {
     }
 
     @Test
-    void handleUnsubscribeEvent_nonLobbyDestination() throws Exception {
-        SessionUnsubscribeEvent event = buildUnsubscribeEvent("/topic/foo", 6L);
+    void handleUnsubscribeEventUserNotInALobby() throws Exception {
+        SessionUnsubscribeEvent event = buildUnsubscribeEvent(99L);
+        UserNotificationDTO userDto = new UserNotificationDTO();
+        userDto.setMessage("error!");
+        userDto.setSuccess(false);
+        Long lobbyId = 4000L;
+        Lobby lobby = new Lobby();
+        lobby.setLobbyId(lobbyId);
+
+        doThrow(new NotFoundException("error!"))
+                .when(lobbyService).getLobbyIdByParticipantId(99L);
+        when(webSocketService.convertToDTO("error!", false)).thenReturn(userDto);
+        when(lobbyService.checkIfLobbyExists(anyLong())).thenReturn(lobby);
+
         listener.handleUnsubscribeEvent(event);
-        verifyNoInteractions(lobbyService, webSocketService);
+
+        verify(lobbyService, never()).leaveLobby(4000L, 99L);
+        verify(webSocketService, never()).broadCastLobbyNotifications(anyLong(), any());
+        verify(webSocketService).lobbyNotifications(99L, userDto);
     }
 }


### PR DESCRIPTION
Close #188, close #186.

- Change the way unsubscribeEventListener get the lobbyId, see #186
- Change the response of the server to the join request of a user that is already in the lobby they are trying to join, see #188