### PR TITLE
Join lobby fix for isLobbyFull check

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -76,20 +76,19 @@ public class LobbyService {
             throw new IllegalStateException(msg);
         }
 
-        // check if lobby is already full
-        if (lobbyIsFull(lobbyId)) {
-            String msg = "The lobby is already full";
-            throw new IllegalStateException(msg);
-        }
-
         // check if user is already in the lobby
         if (!lobby.getUsers().contains(userId)) {
+            // check if lobby is already full
+            if (lobbyIsFull(lobbyId)) {
+                String msg = "The lobby is already full";
+                throw new IllegalStateException(msg);
+            }
             lobby.addUsers(userId);
             user.setLobbyJoined(lobbyId);
             lobby.adddRematchers(userId);
+            userRepository.save(user);
+            userRepository.flush();
         }
-        userRepository.save(user);
-        userRepository.flush();
     }
 
     public void leaveLobby(Long lobbyId, Long userId) throws NotFoundException {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -200,9 +200,42 @@ public class LobbyServiceTest {
         Mockito.when(lobbyRepository.findById(Mockito.any())).thenReturn(Optional.of(testLobby));
         when(userService.checkIfUserExists(Mockito.anyLong())).thenReturn(testUser);
 
+        assertEquals(4, testLobby.getUsers().size());
         assertThrows(
                 IllegalStateException.class, () -> lobbyService
                         .joinLobby(lobbyId, 5L));
+
+    }
+
+    @Test
+    void joinLobby_full_UserAlreadyIn_doesNotThrowException() throws NotFoundException {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+        testLobby.addUsers(3L);
+        testLobby.addUsers(4L);
+
+        Long lobbyId = testLobby.getLobbyId();
+
+        // when -> setup additional mocks for LobbyRepository and userRepository
+        Mockito.when(lobbyRepository.findById(Mockito.any())).thenReturn(Optional.of(testLobby));
+        when(userService.checkIfUserExists(Mockito.anyLong())).thenReturn(testUser);
+        assertEquals(4, testLobby.getUsers().size());
+        assertDoesNotThrow(()->lobbyService.joinLobby(lobbyId, 4L));
+
+    }
+
+    @Test
+    void joinLobby_UserAlreadyIn_doesNothing() throws NotFoundException {
+        testLobby.addUsers(1L);
+        testLobby.addUsers(2L);
+
+        Long lobbyId = testLobby.getLobbyId();
+
+        // when -> setup additional mocks for LobbyRepository and userRepository
+        Mockito.when(lobbyRepository.findById(Mockito.any())).thenReturn(Optional.of(testLobby));
+        when(userService.checkIfUserExists(Mockito.anyLong())).thenReturn(testUser);
+        lobbyService.joinLobby(lobbyId, 2L);
+        assertEquals(2, testLobby.getUsers().size());
 
     }
 


### PR DESCRIPTION
- Fix logic that checks if lobby is full. It now checks if the lobby is full only if the user is not yet in the lobby, before trying to add a new participant