### PR TITLE
Add patch to delete lobby on rematch page reload

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/MessageController.java
@@ -14,7 +14,6 @@ import ch.uzh.ifi.hase.soprafs24.service.TimerService;
 import ch.uzh.ifi.hase.soprafs24.service.WebSocketService;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
 import ch.uzh.ifi.hase.soprafs24.websocket.DTO.*;
-import ch.uzh.ifi.hase.soprafs24.websocket.WebSocketEventListener;
 import javassist.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,19 +38,17 @@ public class MessageController {
     private final WebSocketService webSocketService;
     private final UserService userService;
     private final TimerService timerService;
-    private final WebSocketEventListener webSocketEventListener;
 
     public MessageController(LobbyService lobbyService,
                              GameService gameService,
                              WebSocketService webSocketService,
                              UserService userService,
-                             TimerService timerService, WebSocketEventListener webSocketEventListener) {
+                             TimerService timerService) {
         this.lobbyService = lobbyService;
         this.gameService = gameService;
         this.webSocketService = webSocketService;
         this.userService = userService;
         this.timerService = timerService;
-        this.webSocketEventListener = webSocketEventListener;
     }
 
     @MessageMapping("/startGame/{lobbyId}")

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/MessageControllerTest.java
@@ -174,7 +174,7 @@ class MessageControllerTest {
         }
 
         @Test
-        void testGameUpdateRequest() {
+        void testGameUpdateRequest() throws NotFoundException {
                 Long userId = 1L;
                 StompHeaderAccessor headerAccessor = createHeaderAccessorWithUser(userId);
                 LobbyDTO lobbyDTO = new LobbyDTO();
@@ -195,7 +195,7 @@ class MessageControllerTest {
         }
 
         @Test
-        void testGameUpdateRequest_noGameSession() {
+        void testGameUpdateRequest_noGameSession() throws NotFoundException {
                 Long userId = 1L;
                 StompHeaderAccessor headerAccessor = createHeaderAccessorWithUser(userId);
                 LobbyDTO lobbyDTO = new LobbyDTO();
@@ -580,7 +580,7 @@ class MessageControllerTest {
         }
 
         @Test
-        void testReceiveUpdateGame_WhenChoosing_SendsCaptureOptions() {
+        void testReceiveUpdateGame_WhenChoosing_SendsCaptureOptions() throws NotFoundException {
                 Long userId = 42L;
                 StompHeaderAccessor header = createHeaderAccessorWithUser(userId);
 
@@ -661,7 +661,7 @@ class MessageControllerTest {
         }
 
         @Test
-        void testReceiveUpdateGame_RemChoicePositive_SendsChoiceTime() {
+        void testReceiveUpdateGame_RemChoicePositive_SendsChoiceTime() throws NotFoundException {
                 Long userId = 55L;
                 Long gameId = 600L;
                 StompHeaderAccessor header = createHeaderAccessorWithUser(userId);
@@ -680,7 +680,7 @@ class MessageControllerTest {
         }
 
         @Test
-        void testReceiveUpdateGame_RemChoiceZero_SendsPlayTime() {
+        void testReceiveUpdateGame_RemChoiceZero_SendsPlayTime() throws NotFoundException {
                 Long userId = 66L;
                 Long gameId = 700L;
                 StompHeaderAccessor header = createHeaderAccessorWithUser(userId);


### PR DESCRIPTION
Patch to mitigate rematch page reload by deleting lobby if user navigates to a non-existing game.
- Delete lobby and notify users if game does not exist when an update game request is processed